### PR TITLE
update base conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,11 +5,13 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - numpy=1.17
-  - pandas=0.25
-  - scipy=1.3.2
-  - xarray>=0.12.3
-  - asdf=2.3
+  - numpy>=1.18
+  - pandas>=0.25
+  - scipy
+  - xarray
+  - pint
+  - bottleneck
+  - asdf=2.5.1
   - sphinx
   - recommonmark
   - openpyxl


### PR DESCRIPTION
Add pint & bottleneck for later.
Bump/open some base package versions and fix asdf at 2.5.1 .