### PR TITLE
Enhance CSM get_local_coordinate_system

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04]
         py: [ '3.7', '3.8' ]
@@ -54,13 +55,13 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - name: pip installs
-        run: pip install git+https://github.com/timothycrosley/isort.git
+        run: pip install isort==4.3.21
       - name: show isort diff
         run: |
-          isort ./weldx --diff
+          isort ./weldx/*.py --diff
       - name: run isort
         run: |
-          isort ./weldx --check-only
+          isort ./weldx/*.py -c
 
   vulture:
     name: vulture

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -608,9 +608,6 @@ def test_coordinate_system_init():
     # TODO: implement
 
 
-test_coordinate_system_init()
-
-
 def test_coordinate_system_factories():
     """Test construction of coordinate system class.
 
@@ -1163,7 +1160,7 @@ def test_coordinate_system_manager_add_coordinate_system():
         csm.add_coordinate_system("lcs4", "something", tf.LocalCoordinateSystem())
 
 
-def test_coordinate_system_manager_get_local_coordinate_system_no_time_dependence():
+def test_coordinate_system_manager_get_local_coordinate_system_no_time_dependency():
     """Test the get_local_coordinate_system function.
 
     This function also tests, if the internally performed transformations are correct.
@@ -1223,6 +1220,75 @@ def test_coordinate_system_manager_get_local_coordinate_system_no_time_dependenc
     check_coordinate_system(
         lcs_1_in_lcs3, expected_orientation, expected_coordinates, True
     )
+
+
+def test_coordinate_system_manager_get_local_coordinate_system_time_dependent():
+    """
+    
+    Returns
+    -------
+
+    """
+    lcs_0_time = pd.date_range("2020-01-01", periods=12 * 4 + 1, freq="6H")
+    lcs_0_coordinates = np.zeros([len(lcs_0_time), 3])
+    lcs_0_in_root = tf.LocalCoordinateSystem(
+        coordinates=lcs_0_coordinates, time=lcs_0_time
+    )
+
+    lcs_1_time = pd.date_range("2020-01-01", periods=4, freq="4D")
+    lcs_1_coordinates = [[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]]
+    lcs_1_orientation = tf.rotation_matrix_z(np.array([0, 1 / 3, 2 / 3, 1]) * np.pi * 2)
+    lcs_1_in_lcs0 = tf.LocalCoordinateSystem(
+        coordinates=lcs_1_coordinates, orientation=lcs_1_orientation, time=lcs_1_time
+    )
+
+    lcs_2_time = pd.date_range("2020-01-01", periods=4, freq="4D")
+    lcs_2_coordinates = [1, 0, 0]
+    lcs_2_orientation = tf.rotation_matrix_z(np.array([0, 1 / 3, 2 / 3, 1]) * np.pi * 2)
+    lcs_2_in_lcs1 = tf.LocalCoordinateSystem(
+        coordinates=lcs_2_coordinates, orientation=lcs_2_orientation, time=lcs_2_time
+    )
+
+    csm = tf.CoordinateSystemManager("root")
+    csm.add_coordinate_system("lcs_0", "root", lcs_0_in_root)
+    csm.add_coordinate_system("lcs_1", "lcs_0", lcs_1_in_lcs0)
+    csm.add_coordinate_system("lcs_2", "lcs_1", lcs_2_in_lcs1)
+
+    time_union = csm.time_union()
+    lcs_1_in_root = csm.get_local_coordinate_system("lcs_1", "root")
+    lcs_2_in_root = csm.get_local_coordinate_system("lcs_2", "root")
+
+    assert np.all(lcs_0_time == lcs_1_in_root.time)
+    assert np.all(lcs_0_time == lcs_2_in_root.time)
+
+    num_times = len(lcs_0_time)
+    for i in range(num_times):
+        weight = i / (num_times - 1)
+        angle = weight * 2 * np.pi
+        pos_x = weight * 3
+
+        # check orientations
+        lcs_1_orientation_exp = tf.rotation_matrix_z(angle)
+        lcs_2_orientation_exp = tf.rotation_matrix_z(2 * angle)
+
+        assert ut.matrix_is_close(lcs_1_in_root.orientation[i], lcs_1_orientation_exp)
+        assert ut.matrix_is_close(lcs_2_in_root.orientation[i], lcs_2_orientation_exp)
+
+        # check coordinates
+        c = np.cos(angle)
+        s = np.sin(angle)
+        rot_p_x = c
+        rot_p_y = s
+
+        lcs_1_coordinates_exp = [pos_x, 0, 0]
+        lcs_2_coordinates_exp = [rot_p_x + pos_x, rot_p_y, 0]
+
+        assert ut.vector_is_close(lcs_1_in_root.coordinates[i], lcs_1_coordinates_exp)
+        assert ut.vector_is_close(lcs_2_in_root.coordinates[i], lcs_2_coordinates_exp)
+
+
+# TODO: Remove
+test_coordinate_system_manager_get_local_coordinate_system_time_dependent()
 
 
 def test_coordinate_system_manager_time_union():

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1223,11 +1223,10 @@ def test_coordinate_system_manager_get_local_coordinate_system_no_time_dependenc
 
 
 def test_coordinate_system_manager_get_local_coordinate_system_time_dependent():
-    """
-    
-    Returns
-    -------
+    """Test the get_local_coordinate_system function with time dependent systems.
 
+    The point of this test is to assure that necessary time interpolations do not cause
+    wrong results when transforming to the desired reference coordinate system.
     """
     lcs_0_time = pd.date_range("2020-01-01", periods=12 * 4 + 1, freq="6H")
     lcs_0_coordinates = np.zeros([len(lcs_0_time), 3])
@@ -1249,17 +1248,21 @@ def test_coordinate_system_manager_get_local_coordinate_system_time_dependent():
         coordinates=lcs_2_coordinates, orientation=lcs_2_orientation, time=lcs_2_time
     )
 
+    lcs_3_in_lcs1 = tf.LocalCoordinateSystem(coordinates=[0, 1, 0])
+
     csm = tf.CoordinateSystemManager("root")
     csm.add_coordinate_system("lcs_0", "root", lcs_0_in_root)
     csm.add_coordinate_system("lcs_1", "lcs_0", lcs_1_in_lcs0)
     csm.add_coordinate_system("lcs_2", "lcs_1", lcs_2_in_lcs1)
+    csm.add_coordinate_system("lcs_3", "lcs_1", lcs_3_in_lcs1)
 
-    time_union = csm.time_union()
     lcs_1_in_root = csm.get_local_coordinate_system("lcs_1", "root")
     lcs_2_in_root = csm.get_local_coordinate_system("lcs_2", "root")
+    lcs_3_in_root = csm.get_local_coordinate_system("lcs_3", "root")
 
     assert np.all(lcs_0_time == lcs_1_in_root.time)
     assert np.all(lcs_0_time == lcs_2_in_root.time)
+    assert np.all(lcs_0_time == lcs_3_in_root.time)
 
     num_times = len(lcs_0_time)
     for i in range(num_times):
@@ -1273,6 +1276,7 @@ def test_coordinate_system_manager_get_local_coordinate_system_time_dependent():
 
         assert ut.matrix_is_close(lcs_1_in_root.orientation[i], lcs_1_orientation_exp)
         assert ut.matrix_is_close(lcs_2_in_root.orientation[i], lcs_2_orientation_exp)
+        assert ut.matrix_is_close(lcs_3_in_root.orientation[i], lcs_1_orientation_exp)
 
         # check coordinates
         c = np.cos(angle)
@@ -1282,9 +1286,11 @@ def test_coordinate_system_manager_get_local_coordinate_system_time_dependent():
 
         lcs_1_coordinates_exp = [pos_x, 0, 0]
         lcs_2_coordinates_exp = [rot_p_x + pos_x, rot_p_y, 0]
+        lcs_3_coordinates_exp = [-rot_p_y + pos_x, rot_p_x, 0]
 
         assert ut.vector_is_close(lcs_1_in_root.coordinates[i], lcs_1_coordinates_exp)
         assert ut.vector_is_close(lcs_2_in_root.coordinates[i], lcs_2_coordinates_exp)
+        assert ut.vector_is_close(lcs_3_in_root.coordinates[i], lcs_3_coordinates_exp)
 
 
 # TODO: Remove
@@ -1528,3 +1534,5 @@ def test_coordinate_system_manager_data_assignment_and_retrieval():
 
 
 # TODO: Test time dependent get_local_coordinate_system
+
+test_coordinate_system_manager_get_local_coordinate_system_time_dependent()

--- a/weldx/__init__.py
+++ b/weldx/__init__.py
@@ -1,10 +1,7 @@
 import warnings
 
-__all__ = ["geometry", "transformations", "utility", "asdf", "Q_"]
-
 # asdf extensions and tags
 import weldx.asdf
-
 # geometry packages
 import weldx.geometry
 import weldx.transformations
@@ -14,10 +11,11 @@ from weldx.constants import WELDX_QUANTITY as Q_
 # versioneer
 from ._version import get_versions
 
-
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     Q_([])
 
 __version__ = get_versions()["version"]
 del get_versions
+
+__all__ = ["geometry", "transformations", "utility", "asdf", "Q_"]

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -1044,15 +1044,15 @@ class CoordinateSystemManager:
 
         time_union = self.time_union(path_edges)
 
-        lcs = self.graph.edges[path[0], path[1]]["lcs"]
+        lcs = self.graph.edges[path_edges[0]]["lcs"]
+
         if time_union is not None:
             lcs = lcs.interp_time(time_union)
-
-        for edge in path_edges[1:]:
-            lcs_rhs = self.graph.edges[edge[0], edge[1]]["lcs"]
-            if time_union is not None:
-                lcs_rhs = lcs_rhs.interp_time(time_union)
-            lcs = lcs + lcs_rhs
+            for edge in path_edges[1:]:
+                lcs = lcs + self.graph.edges[edge]["lcs"].interp_time(time_union)
+        else:
+            for edge in path_edges[1:]:
+                lcs = lcs + self.graph.edges[edge]["lcs"]
 
         return lcs
 

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -1021,9 +1021,7 @@ class CoordinateSystemManager:
         path = nx.shortest_path(
             self.graph, coordinate_system_name, reference_system_name
         )
-        path_edges = []
-        for i in range(len(path) - 1):
-            path_edges.append((path[i], path[i + 1]))
+        path_edges = [edge for edge in zip(path[:-1], path[1:])]
 
         time_union = self.time_union(path_edges)
 
@@ -1031,13 +1029,12 @@ class CoordinateSystemManager:
         if time_union is not None:
             lcs = lcs.interp_time(time_union)
 
-        length_path = len(path) - 1
-        if length_path > 1:
-            for i in np.arange(1, length_path):
-                lcs_rhs = self.graph.edges[path[i], path[i + 1]]["lcs"]
-                if time_union is not None:
-                    lcs_rhs = lcs_rhs.interp_time(time_union)
-                lcs = lcs + lcs_rhs
+        for edge in path_edges[1:]:
+            lcs_rhs = self.graph.edges[edge[0], edge[1]]["lcs"]
+            if time_union is not None:
+                lcs_rhs = lcs_rhs.interp_time(time_union)
+            lcs = lcs + lcs_rhs
+
         return lcs
 
     def has_coordinate_system(self, coordinate_system_name: Hashable) -> bool:

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -1034,9 +1034,10 @@ class CoordinateSystemManager:
         length_path = len(path) - 1
         if length_path > 1:
             for i in np.arange(1, length_path):
-                lcs = lcs + self.graph.edges[path[i], path[i + 1]]["lcs"].interp_time(
-                    time_union
-                )
+                lcs_rhs = self.graph.edges[path[i], path[i + 1]]["lcs"]
+                if time_union is not None:
+                    lcs_rhs = lcs_rhs.interp_time(time_union)
+                lcs = lcs + lcs_rhs
         return lcs
 
     def has_coordinate_system(self, coordinate_system_name: Hashable) -> bool:

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -999,6 +999,25 @@ class CoordinateSystemManager:
     ) -> LocalCoordinateSystem:
         """Get a coordinate system in relation to another reference system.
 
+        If any coordinate system that is involved in the coordinate transformation has
+        a time dependency, the union of all coordinate systems' timestamps is
+        determined. Subsequently, all coordinate systems are interpolated in time to
+        match the time union before they are used in the transformation. The purpose is
+        to prevent interpolation errors when rotations are involved. In result, the
+        returned 'LocalCoordinateSystem' timestamps equals the time union of all
+        coordinate systems that were used during the transformation.
+
+        Without the preceding time union interpolation, multiple subsequent
+        transformations can cause changes in the rotation direction and transform
+        circular movements into linear ones. The reason for this is that each individual
+        transformation using the 'LocalCoordinateSystem's + operator generates a new
+        ''set of keyframes'' for the next transformation. Those ''keyframes'' do not
+        preserve the rotational trajectory of a coordinate system attached to a rotating
+        parent system. Additionally, the rotation angle between two keyframes after a
+        transformation might exceed 180°. Since the employed SLERP method always uses
+        the smaller rotation angle, subsequent interpolations will cause a change of the
+        rotation order.
+
         Parameters
         ----------
         coordinate_system_name :

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -1021,7 +1021,16 @@ class CoordinateSystemManager:
         path = nx.shortest_path(
             self.graph, coordinate_system_name, reference_system_name
         )
+        path_edges = []
+        for i in range(len(path) - 1):
+            path_edges.append((path[i], path[i + 1]))
+
+        time_union = self.time_union(path_edges)
+
         lcs = self.graph.edges[path[0], path[1]]["lcs"]
+        if time_union is not None:
+            lcs = lcs.interp_time(time_union)
+
         length_path = len(path) - 1
         if length_path > 1:
             for i in np.arange(1, length_path):

--- a/weldx/transformations.py
+++ b/weldx/transformations.py
@@ -1034,7 +1034,9 @@ class CoordinateSystemManager:
         length_path = len(path) - 1
         if length_path > 1:
             for i in np.arange(1, length_path):
-                lcs = lcs + self.graph.edges[path[i], path[i + 1]]["lcs"]
+                lcs = lcs + self.graph.edges[path[i], path[i + 1]]["lcs"].interp_time(
+                    time_union
+                )
         return lcs
 
     def has_coordinate_system(self, coordinate_system_name: Hashable) -> bool:


### PR DESCRIPTION
This PR fixes the problem that rotations might be affected by serious interpolation errors if a time-dependent coordinate system was transformed to another reference system.