### PR TITLE
skip slow tests by default

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
       - name: pytest
         shell: bash -l {0}
         run: |
-          pytest
+          pytest --runslow
           coverage xml
 
       - name: codecov.io

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -79,4 +79,4 @@ jobs:
         run: pip install vulture==1.4
       - name: run vulture
         run: |
-          vulture . --exclude weldx/asdf/,versioneer.py,weldx/_version.py
+          vulture . --exclude weldx/asdf/,versioneer.py,weldx/_version.py,tests/conftest.py

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -66,6 +66,9 @@ excluded_words:
   - timedeltaindex
   - datetimeindex
   - isoformat
+  # pytest --------------------------------------
+  - conftest
+  - addoption
   # jupyter notebooks ---------------------------
   - jupyter
   - nbformat

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,17 +17,17 @@ exclude =
     .vulture_whitelist.py
 
 [pydocstyle]
-match = (?!__)(?!versioneer)(?!_version).*\.py
+match = (?!__)(?!versioneer)(?!_version)(?!conftest).*\.py
 match_dir = [^\.][^\docs].*
 ignore = D203,D213
 
 [tool:pytest]
-addopts = --tb=short --color=yes --cov=weldx --cov-report=term-missing:skip-covered
+addopts = --tb=short --color=yes --cov=weldx --cov-report=term-missing:skip-covered -rs
 asdf_schema_root = weldx/asdf/schemas
 #asdf_schema_tests_enabled = true
 # custom test markers, see https://docs.pytest.org/en/latest/example/markers.html#mark-examples
 markers =
-    slow: marks tests as slow (deselect from pytest run with '-m "not slow"' option)
+    slow: marks tests as slow to run (skipped by default, enable with --runslow option)
 
 [isort]
 multi_line_output=3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
Skip tests marked as slow in default pytest run (for local speedup) as described here https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option.

Slow tests can be enabled with `--runslow` option.
All tests still enabled in CI runs.