### PR TITLE
enable pint auto_reduce_dimensions for UnitRegistry

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pint
 import pytest
+from numpy.core._exceptions import UFuncTypeError
 
 import weldx.utility as ut
 from weldx.constants import WELDX_QUANTITY as Q_
@@ -305,6 +306,13 @@ class TestTimeSeries:
             (me_param_units, None, None, Exception, "# incompatible parameter units"),
             (me_time_vec, None, None, Exception, "# not compatible with time vectors"),
             ("a string", None, None, TypeError, "# wrong data type"),
+            (
+                ME("a*t", {"a": Q_(2, "1/ms")}),
+                None,
+                None,
+                UFuncTypeError,
+                "# uncaught float <-> int inplace arithmetic",
+            ),
         ],
         ids=get_test_name,
     )
@@ -323,7 +331,7 @@ class TestTimeSeries:
     values_unit_prefix_wrong = Q_(np.array([10, 11, 12, 14, 16]), "m")
     params_wrong_values = {"a": Q_(2, "1/s"), "b": Q_(-1, "")}
     params_wrong_unit = {"a": Q_(2, "g/s"), "b": Q_(-2, "g")}
-    params_wrong_unit_prefix = {"a": Q_(2, "m/ms"), "b": Q_(-2, "m")}
+    params_wrong_unit_prefix = {"a": Q_(2.0, "m/ms"), "b": Q_(-2, "m")}
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -3,7 +3,11 @@
 from pint import UnitRegistry
 
 WELDX_UNIT_REGISTRY = UnitRegistry(
-    preprocessors=[lambda string: string.replace("%", "percent")]  # allow use of %-sign
+    preprocessors=[
+        lambda string: string.replace("%", "percent")
+    ],  # allow use of %-sign
+    # force_ndarray_like=True,
+    auto_reduce_dimensions=True,
 )
 WELDX_QUANTITY = WELDX_UNIT_REGISTRY.Quantity
 

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -6,7 +6,7 @@ WELDX_UNIT_REGISTRY = UnitRegistry(
     preprocessors=[
         lambda string: string.replace("%", "percent")
     ],  # allow use of %-sign
-    # force_ndarray_like=True,
+    force_ndarray_like=False,
     auto_reduce_dimensions=True,
 )
 WELDX_QUANTITY = WELDX_UNIT_REGISTRY.Quantity

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pint
 import sympy
 import xarray as xr
+from numpy.core._exceptions import UFuncTypeError
 
 import weldx.utility as ut
 from weldx.constants import WELDX_QUANTITY as Q_
@@ -315,8 +316,10 @@ class TimeSeries:
             self._time_var_name = time_var_name
 
             try:
-                self.interp_time(Q_([1, 2], "second").astype(float))
-                self.interp_time(Q_([1, 2, 3], "second").astype(float))
+                self.interp_time(Q_([1, 2], "second"))
+                self.interp_time(Q_([1, 2, 3], "second"))
+            except UFuncTypeError as e:
+                raise e
             except Exception as e:
                 raise Exception(
                     "The expression can not be evaluated with arrays of time deltas. "

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -315,8 +315,8 @@ class TimeSeries:
             self._time_var_name = time_var_name
 
             try:
-                self.interp_time(Q_([1, 2], "second"))
-                self.interp_time(Q_([1, 2, 3], "second"))
+                self.interp_time(Q_([1, 2], "second").astype(float))
+                self.interp_time(Q_([1, 2, 3], "second").astype(float))
             except Exception as e:
                 raise Exception(
                     "The expression can not be evaluated with arrays of time deltas. "


### PR DESCRIPTION
## Changes
Sets `auto_reduce_dimensions = True` for the default `pint.UnitRegistry`. For some reason this caused the `MathExpression` tests to fail because it encountered `float` <-> `int` arithmetic (which was forbidden). Hence I change the default code to cast as float.

A MWE to reproduce the error
~~~python
import pint
ureg = pint.UnitRegistry(auto_reduce_dimensions=True)
Q_ = ureg.Quantity

a = Q_(np.arange(3),"m/s")
b = Q_(3,"ms")

a*b
~~~

here is the error when using MathExpression/TimeSeries, caused by this test (note use of milliseconds)
https://github.com/BAMWelDX/weldx/blob/a545f0788d479138feffb84866d881d27fcc97ff/tests/test_core.py#L326

~~~python
Notebook error:
CellExecutionError in tutorials\timeseries_01.ipynb:
------------------
t2 = Q_(np.arange(101)*100,"ms")
ts = ts_expr.interp_time(t2)
plot_ts(ts)
------------------

---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
<ipython-input-1-04c9613a6b7b> in <module>
      1 t2 = Q_(np.arange(101)*100,"ms")
----> 2 ts = ts_expr.interp_time(t2)
      3 plot_ts(ts)

C:\Python\weldx\weldx\core.py in interp_time(self, time, time_unit)
    499
    500         # evaluate expression
--> 501         data = self._data.evaluate(**{self._time_var_name: time_q})
    502         if isinstance(data.m, np.ndarray):  # make sure we continue with floats
    503             data = Q_(data.m.astype(float), data.units)

C:\Python\weldx\weldx\core.py in evaluate(self, **kwargs)
    230             )
    231         inputs = {**kwargs, **self._parameters}
--> 232         return self.function(**inputs)
    233
    234

<lambdifygenerated-1> in _lambdifygenerated(t, b, a)
      1 def _lambdifygenerated(t, b, a):
----> 2     return (a*t + b)

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in __mul__(self, other)
   1248
   1249     def __mul__(self, other):
-> 1250         return self._mul_div(other, operator.mul)
   1251
   1252     __rmul__ = __mul__

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in wrapped(self, *args, **kwargs)
    113         elif isinstance(other, list) and other and isinstance(other[0], type(self)):
    114             return NotImplemented
--> 115         return f(self, *args, **kwargs)
    116
    117     return wrapped

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in wrapped(self, *args, **kwargs)
     96         try:
     97             if result._REGISTRY.auto_reduce_dimensions:
---> 98                 result.ito_reduced_units()
     99         except AttributeError:
    100             pass

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in ito_reduced_units(self)
    727                         break
    728
--> 729         return self.ito(newunits)
    730
    731     def to_reduced_units(self):

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in ito(self, other, *contexts, **ctx_kwargs)
    636         other = to_units_container(other, self._REGISTRY)
    637
--> 638         self._magnitude = self._convert_magnitude(other, *contexts, **ctx_kwargs)
    639         self._units = other
    640

~\Anaconda3\envs\weldx\lib\site-packages\pint\quantity.py in _convert_magnitude(self, other, *contexts, **ctx_kwargs)
    619             self._units,
    620             other,
--> 621             inplace=is_duck_array_type(type(self._magnitude)),
    622         )
    623

~\Anaconda3\envs\weldx\lib\site-packages\pint\registry.py in convert(self, value, src, dst, inplace)
    952             return value
    953
--> 954         return self._convert(value, src, dst, inplace)
    955
    956     def _convert(self, value, src, dst, inplace=False, check_dimensionality=True):

~\Anaconda3\envs\weldx\lib\site-packages\pint\registry.py in _convert(self, value, src, dst, inplace)
   1838                 value, src = src._magnitude, src._units
   1839
-> 1840         return super()._convert(value, src, dst, inplace)
   1841
   1842     def _get_compatible_units(self, input_units, group_or_system):

~\Anaconda3\envs\weldx\lib\site-packages\pint\registry.py in _convert(self, value, src, dst, inplace)
   1440
   1441         if not (src_offset_unit or dst_offset_unit):
-> 1442             return super()._convert(value, src, dst, inplace)
   1443
   1444         src_dim = self._get_dimensionality(src)

~\Anaconda3\envs\weldx\lib\site-packages\pint\registry.py in _convert(self, value, src, dst, inplace, check_dimensionality)
    999
   1000         if inplace:
-> 1001             value *= factor
   1002         else:
   1003             value = value * factor

UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int32') with casting rule 'same_kind'
UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int32') with casting rule 'same_kind'

~~~

We should discuss ways to handle this problem by default (do we want to cast all quantities to float per by default? Maybe add a check to `Q_`?)

## Related Issues
Closes # (add issue numbers)

## Checks
- [ ] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
