### PR TITLE
support legacy matplotlib settings for traitlets<5

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,8 @@ import pathlib
 import shutil
 import sys
 
+import traitlets
+
 import weldx
 
 sys.path.insert(0, os.path.abspath(""))
@@ -96,8 +98,12 @@ master_doc = "index"
 nbsphinx_execute = "always"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
-    "--InlineBackend.rc <figure.dpi=96>",
 ]
+
+if traitlets.__version__ < "5":
+    nbsphinx_execute_arguments.append("--InlineBackend.rc={'figure.dpi': 96}")
+else:
+    nbsphinx_execute_arguments.append("--InlineBackend.rc <figure.dpi=96>")
 
 # Select notebook kernel for nbsphinx
 # default "python3" is needed for readthedocs run


### PR DESCRIPTION
## Changes
Support sphinx build with traitlets versions <5 and >=5 without warnings

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
