### PR TITLE
add asdf docs and remove magic methods from class-template.rst

### DIFF
--- a/doc/_templates/class-template.rst
+++ b/doc/_templates/class-template.rst
@@ -12,13 +12,7 @@
       :toctree:
       :nosignatures:
    {% for item in all_methods %}
-      {%- if not item.startswith('_') or item in ['__init__',
-                                                  '__eq__',
-                                                  '__repr__',
-                                                  '__str__',
-                                                  '__add__',
-                                                  '__sub__',
-                                                  ] %}
+      {%- if not item.startswith('_')%}
        ~{{ name }}.{{ item }}
        {%- endif -%}
    {%- endfor %}

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,15 +5,29 @@ API
 **Python modules**
 
 .. autosummary::
-   :toctree: _autosummary
-   :caption: API Reference
-   :template: module-template.rst
-   :recursive:
+    :toctree: _autosummary
+    :caption: API Reference
+    :template: module-template.rst
+    :recursive:
 
-   weldx.constants
-   weldx.core
-   weldx.geometry
-   weldx.measurement
-   weldx.transformations
-   weldx.utility
-   weldx.visualization
+    weldx.constants
+    weldx.core
+    weldx.geometry
+    weldx.measurement
+    weldx.transformations
+    weldx.utility
+    weldx.visualization
+
+
+**ASDF modules**
+
+.. autosummary::
+    :toctree: _autosummary
+    :caption: ASDF API Reference
+    :template: module-template.rst
+    :recursive:
+
+    weldx.asdf.extension
+    weldx.asdf.utils
+    weldx.asdf.validators
+

--- a/doc/asdf-extension.rst
+++ b/doc/asdf-extension.rst
@@ -4,10 +4,10 @@ ASDF Extension
 This page contains documentation and examples for custom additions to the ASDF schemas used in WelDX.
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   validators
-   shape-validation
-   unit-validation
-   welding-processes
+    validators
+    shape-validation
+    unit-validation
+    welding-processes
 

--- a/doc/asdf-schemas.rst
+++ b/doc/asdf-schemas.rst
@@ -2,10 +2,10 @@ ASDF Schema Definitions
 =======================
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   schemas/core.rst
-   schemas/equipment.rst
-   schemas/measurement.rst
-   schemas/process.rst
-   schemas/time.rst
+    schemas/core.rst
+    schemas/equipment.rst
+    schemas/measurement.rst
+    schemas/process.rst
+    schemas/time.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,7 +98,7 @@ source_suffix = {
 master_doc = "index"
 
 # nbsphinx
-nbsphinx_execute = "never"
+nbsphinx_execute = "always"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,6 +67,9 @@ extensions = [
 # autosummary --------------------------------------------------------------------------
 autosummary_generate = True
 
+# add __init__ docstrings to class documentation
+autoclass_content = "both"
+
 # numpydoc option documentation:
 # https://numpydoc.readthedocs.io/en/latest/install.html
 numpydoc_use_plots = True
@@ -95,7 +98,7 @@ source_suffix = {
 master_doc = "index"
 
 # nbsphinx
-nbsphinx_execute = "always"
+nbsphinx_execute = "never"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
 ]
@@ -189,6 +192,7 @@ intersphinx_mapping = {
     # "dask": ("https://docs.dask.org/en/latest", None),
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),
+    "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
 }
 
 # Disable warnings caused by a bug -----------------------------------------------------

--- a/doc/devdoc.rst
+++ b/doc/devdoc.rst
@@ -4,8 +4,8 @@ Developers Documentation
 =================================
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Contents:
-   :glob:
+    :maxdepth: 1
+    :caption: Contents:
+    :glob:
 
-   developers_doc/*
+    developers_doc/*

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,13 +30,13 @@ Contents
 ########
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   tutorials
-   asdf-extension
-   devdoc
-   api
-   asdf-schemas
-   CHANGELOG
-   legal-notice
+    tutorials
+    asdf-extension
+    devdoc
+    api
+    asdf-schemas
+    CHANGELOG
+    legal-notice
 

--- a/doc/schemas/core.rst
+++ b/doc/schemas/core.rst
@@ -5,13 +5,13 @@ The ``core`` directory contains schema implementations for the base classes.
 
 .. asdf-autoschemas::
 
-   core/mathematical_expression-1.0.0
-   core/time_series-1.0.0
-   core/variable-1.0.0
-   core/dimension-1.0.0
-   core/iso_groove-1.0.0
-   core/data_array-1.0.0
-   core/dataset-1.0.0
+    core/mathematical_expression-1.0.0
+    core/time_series-1.0.0
+    core/variable-1.0.0
+    core/dimension-1.0.0
+    core/iso_groove-1.0.0
+    core/data_array-1.0.0
+    core/dataset-1.0.0
 
 Transformations
 ===============
@@ -20,8 +20,8 @@ The ``transformations`` directory contains schema implementations for the base c
 
 .. asdf-autoschemas::
 
-   core/transformations/coordinate_system_hierarchy_subsystem-1.0.0
-   core/transformations/coordinate_system_hierarchy-1.0.0
-   core/transformations/coordinate_transformation-1.0.0
-   core/transformations/local_coordinate_system-1.0.0
-   core/transformations/rotation-1.0.0
+    core/transformations/coordinate_system_hierarchy_subsystem-1.0.0
+    core/transformations/coordinate_system_hierarchy-1.0.0
+    core/transformations/coordinate_transformation-1.0.0
+    core/transformations/local_coordinate_system-1.0.0
+    core/transformations/rotation-1.0.0

--- a/doc/schemas/equipment.rst
+++ b/doc/schemas/equipment.rst
@@ -5,4 +5,4 @@ The ``equipment`` directory contains schema implementations for the base classes
 
 .. asdf-autoschemas::
 
-   equipment/generic_equipment-1.0.0
+    equipment/generic_equipment-1.0.0

--- a/doc/schemas/measurement.rst
+++ b/doc/schemas/measurement.rst
@@ -5,10 +5,10 @@ The ``measurement`` directory contains schema implementations for the base class
 
 .. asdf-autoschemas::
 
-   measurement/data_transformation-1.0.0
-   measurement/data-1.0.0
-   measurement/error-1.0.0
-   measurement/measurement_chain-1.0.0
-   measurement/measurement-1.0.0
-   measurement/signal-1.0.0
-   measurement/source-1.0.0
+    measurement/data_transformation-1.0.0
+    measurement/data-1.0.0
+    measurement/error-1.0.0
+    measurement/measurement_chain-1.0.0
+    measurement/measurement-1.0.0
+    measurement/signal-1.0.0
+    measurement/source-1.0.0

--- a/doc/schemas/process.rst
+++ b/doc/schemas/process.rst
@@ -5,6 +5,6 @@ The ``Process`` directory contains schema implementations for the base classes.
 
 .. asdf-autoschemas::
 
-   process/generic-1.0.0
-   process/GMAW-1.0.0
-   process/terms-1.0.0
+    process/generic-1.0.0
+    process/GMAW-1.0.0
+    process/terms-1.0.0

--- a/doc/schemas/time.rst
+++ b/doc/schemas/time.rst
@@ -5,7 +5,7 @@ The ``time`` directory contains schema implementations for :code:`pandas` time t
 
 .. asdf-autoschemas::
 
-   time/datetimeindex-1.0.0
-   time/timedelta-1.0.0
-   time/timedeltaindex-1.0.0
-   time/timestamp-1.0.0
+    time/datetimeindex-1.0.0
+    time/timedelta-1.0.0
+    time/timedeltaindex-1.0.0
+    time/timestamp-1.0.0

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -4,23 +4,23 @@ Tutorials
 =================================
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Basics
-   :glob:
+    :maxdepth: 1
+    :caption: Basics
+    :glob:
 
-   tutorials/transformations_01_coordinate_systems
-   tutorials/transformations_02_coordinate_system_manager
-   tutorials/geometry_01_profiles
-   tutorials/groove_types_01
-   tutorials/geometry_02_geometry
-   tutorials/timeseries_01
+    tutorials/transformations_01_coordinate_systems
+    tutorials/transformations_02_coordinate_system_manager
+    tutorials/geometry_01_profiles
+    tutorials/groove_types_01
+    tutorials/geometry_02_geometry
+    tutorials/timeseries_01
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Examples
-   :glob:
+    :maxdepth: 1
+    :caption: Examples
+    :glob:
 
-   tutorials/measurement_example
-   tutorials/welding_example_01_basics
-   tutorials/welding_example_02_weaving
-   tutorials/GMAW_process
+    tutorials/measurement_example
+    tutorials/welding_example_01_basics
+    tutorials/welding_example_02_weaving
+    tutorials/GMAW_process

--- a/weldx/asdf/utils.py
+++ b/weldx/asdf/utils.py
@@ -15,11 +15,11 @@ def drop_none_attr(node):
     The function requires the node to be convertible to dictionary via __dict__. And can
     therefor be applied to all classes created using the @dataclass operator.
     The result is "clean" dictionary with all None entries removed.
-    A simple `to_tree()` function could be implemented as such:
-        ```python
+    A simple `to_tree()` function could be implemented as such::
+
         def to_tree(cls, node, ctx):
             tree = drop_none_attr(node)
-            return tree```
+            return tree
 
     Parameters
     ----------


### PR DESCRIPTION
adds init docstring to class documentation

## Changes
- remove magic methods like `__init__`, `__str__` etc. from class docs
- add init docstring to class documentation 
- add main asdf python modules to documentation

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
