### PR TITLE
add sphinx_autodoc_typehints and list (default) napoleon settings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,7 +119,7 @@ source_suffix = {
 master_doc = "index"
 
 # nbsphinx
-nbsphinx_execute = "never"
+nbsphinx_execute = "always"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_asdf",
     "numpydoc",
+    "sphinx_autodoc_typehints",  # list after napoleon
 ]
 
 # autosummary --------------------------------------------------------------------------
@@ -83,6 +84,20 @@ numpydoc_xref_param_type = True
 # numpydoc_xref_ignore = set - check documentation
 
 
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_type_aliases = None
+
 # --------------------------------------------------------------------------------------
 
 # The suffix of source filenames.
@@ -98,7 +113,7 @@ source_suffix = {
 master_doc = "index"
 
 # nbsphinx
-nbsphinx_execute = "always"
+nbsphinx_execute = "never"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,6 +98,12 @@ napoleon_use_param = True
 napoleon_use_rtype = True
 napoleon_type_aliases = None
 
+# sphinx-autodoc-typehints https://github.com/agronholm/sphinx-autodoc-typehints
+set_type_checking_flag = False
+typehints_fully_qualified = False
+always_document_param_types = False
+typehints_document_rtype = True
+
 # --------------------------------------------------------------------------------------
 
 # The suffix of source filenames.

--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - pydata-sphinx-theme
   - numpydoc>=0.5
+  - sphinx_autodoc_typehints
   # pip packages
   - pip
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - pydata-sphinx-theme
   - numpydoc>=0.5
-  - sphinx_autodoc_typehints
+  - sphinx-autodoc-typehints
   # pip packages
   - pip
   - pip:


### PR DESCRIPTION
## Changes
add [sphinx-autodoc-typehints](https://github.com/agronholm/sphinx-autodoc-typehints) with default config
will move type-hints from function arguments to parameter field (if no explicit parameter type given in docstring)

similar behavior possible with [`"sphinx.ext.autodoc.typehints"`](https://www.sphinx-doc.org/en/2.0/usage/extensions/autodoc.html#generating-documents-from-type-annotations) setting `autodoc_typehints = "description"` (formatting not as nice)

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
