### PR TITLE
Dataclass check decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.2.2 (unreleased)
+### added
+- Added `weldx.utility.ureg_check_class` class decorator to enable `pint` dimensionality checks with `@dataclass`.
+
 ## 0.2.1 (26.10.2020)
 ### changes
 - Documentation

--- a/weldx/asdf/tags/weldx/core/iso_groove.py
+++ b/weldx/asdf/tags/weldx/core/iso_groove.py
@@ -475,7 +475,7 @@ class BaseGroove:
         raise NotImplementedError("to_profile() must be defined in subclass.")
 
 
-@ureg_check_class(("[length]", "[]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[length]", "[length]", None)
 @dataclass
 class VGroove(BaseGroove):
     """A Single-V Groove.
@@ -557,7 +557,7 @@ class VGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[]", "[length]", "[length]", "[length]", None)
 @dataclass
 class VVGroove(BaseGroove):
     """A VV-Groove.
@@ -645,7 +645,7 @@ class VVGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[]", "[length]", "[length]", "[length]", None)
 @dataclass
 class UVGroove(BaseGroove):
     """A UV-Groove.
@@ -731,7 +731,7 @@ class UVGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[length]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[length]", "[length]", "[length]", None)
 @dataclass
 class UGroove(BaseGroove):
     """An U-Groove.
@@ -841,7 +841,7 @@ class UGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[length]", None))
+@ureg_check_class("[length]", "[length]", None)
 @dataclass
 class IGroove(BaseGroove):
     """An I-Groove.
@@ -892,7 +892,7 @@ class IGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[length]", "[length]", None)
 @dataclass
 class HVGroove(BaseGroove):
     """A HV-Groove.
@@ -971,7 +971,7 @@ class HVGroove(BaseGroove):
         return geo.Profile([shape_h, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[length]", "[length]", "[length]", None))
+@ureg_check_class("[length]", "[]", "[length]", "[length]", "[length]", None)
 @dataclass
 class HUGroove(BaseGroove):
     """A HU-Groove.
@@ -1057,7 +1057,7 @@ class HUGroove(BaseGroove):
 
 
 # double Grooves
-@ureg_check_class(("[length]", "[]", "[]", "[length]", None, None, None, None))
+@ureg_check_class("[length]", "[]", "[]", "[length]", None, None, None, None)
 @dataclass
 class DVGroove(BaseGroove):
     """A DV-Groove.
@@ -1155,18 +1155,7 @@ class DVGroove(BaseGroove):
 
 
 @ureg_check_class(
-    (
-        "[length]",
-        "[]",
-        "[]",
-        "[length]",
-        "[length]",
-        "[length]",
-        None,
-        None,
-        None,
-        None,
-    )
+    "[length]", "[]", "[]", "[length]", "[length]", "[length]", None, None, None, None,
 )
 @dataclass
 class DUGroove(BaseGroove):
@@ -1276,7 +1265,7 @@ class DUGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
-@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", None, None, None))
+@ureg_check_class("[length]", "[]", "[]", "[length]", "[length]", None, None, None)
 @dataclass
 class DHVGroove(BaseGroove):
     """A DHV-Groove.
@@ -1353,18 +1342,16 @@ class DHVGroove(BaseGroove):
 
 
 @ureg_check_class(
-    (
-        "[length]",
-        "[]",
-        "[]",
-        "[length]",
-        "[length]",
-        "[length]",
-        "[length]",
-        None,
-        None,
-        None,
-    )
+    "[length]",
+    "[]",
+    "[]",
+    "[length]",
+    "[length]",
+    "[length]",
+    "[length]",
+    None,
+    None,
+    None,
 )
 @dataclass
 class DHUGroove(BaseGroove):
@@ -1449,7 +1436,7 @@ class DHUGroove(BaseGroove):
 
 
 # Frontal Face - Groove
-@ureg_check_class(("[length]", None, None, None, None, None,))
+@ureg_check_class("[length]", None, None, None, None, None)
 @dataclass
 class FFGroove(BaseGroove):
     """A Frontal Face Groove.

--- a/weldx/asdf/tags/weldx/core/iso_groove.py
+++ b/weldx/asdf/tags/weldx/core/iso_groove.py
@@ -11,6 +11,7 @@ from weldx.asdf.types import WeldxType
 from weldx.asdf.utils import drop_none_attr
 from weldx.asdf.validators import wx_unit_validator
 from weldx.constants import WELDX_QUANTITY as Q_
+from weldx.utility import ureg_check_class
 
 _DEFAULT_LEN_UNIT = "mm"
 
@@ -474,6 +475,7 @@ class BaseGroove:
         raise NotImplementedError("to_profile() must be defined in subclass.")
 
 
+@ureg_check_class(("[length]", "[]", "[length]", "[length]", None))
 @dataclass
 class VGroove(BaseGroove):
     """A Single-V Groove.
@@ -555,6 +557,7 @@ class VGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", "[length]", None))
 @dataclass
 class VVGroove(BaseGroove):
     """A VV-Groove.
@@ -642,6 +645,7 @@ class VVGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", "[length]", None))
 @dataclass
 class UVGroove(BaseGroove):
     """A UV-Groove.
@@ -727,6 +731,7 @@ class UVGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[length]", "[length]", "[length]", None))
 @dataclass
 class UGroove(BaseGroove):
     """An U-Groove.
@@ -836,6 +841,7 @@ class UGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[length]", None))
 @dataclass
 class IGroove(BaseGroove):
     """An I-Groove.
@@ -886,6 +892,7 @@ class IGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[length]", "[length]", None))
 @dataclass
 class HVGroove(BaseGroove):
     """A HV-Groove.
@@ -964,6 +971,7 @@ class HVGroove(BaseGroove):
         return geo.Profile([shape_h, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[length]", "[length]", "[length]", None))
 @dataclass
 class HUGroove(BaseGroove):
     """A HU-Groove.
@@ -1049,6 +1057,7 @@ class HUGroove(BaseGroove):
 
 
 # double Grooves
+@ureg_check_class(("[length]", "[]", "[]", "[length]", None, None, None, None))
 @dataclass
 class DVGroove(BaseGroove):
     """A DV-Groove.
@@ -1145,6 +1154,20 @@ class DVGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(
+    (
+        "[length]",
+        "[]",
+        "[]",
+        "[length]",
+        "[length]",
+        "[length]",
+        None,
+        None,
+        None,
+        None,
+    )
+)
 @dataclass
 class DUGroove(BaseGroove):
     """A DU-Groove
@@ -1253,6 +1276,7 @@ class DUGroove(BaseGroove):
         return geo.Profile([shape, shape_r], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(("[length]", "[]", "[]", "[length]", "[length]", None, None, None))
 @dataclass
 class DHVGroove(BaseGroove):
     """A DHV-Groove.
@@ -1328,6 +1352,20 @@ class DHVGroove(BaseGroove):
         return geo.Profile([left_shape, right_shape], units=_DEFAULT_LEN_UNIT)
 
 
+@ureg_check_class(
+    (
+        "[length]",
+        "[]",
+        "[]",
+        "[length]",
+        "[length]",
+        "[length]",
+        "[length]",
+        None,
+        None,
+        None,
+    )
+)
 @dataclass
 class DHUGroove(BaseGroove):
     """A DHU-Groove.
@@ -1411,6 +1449,7 @@ class DHUGroove(BaseGroove):
 
 
 # Frontal Face - Groove
+@ureg_check_class(("[length]", None, None, None, None, None,))
 @dataclass
 class FFGroove(BaseGroove):
     """A Frontal Face Groove.

--- a/weldx/utility.py
+++ b/weldx/utility.py
@@ -16,7 +16,36 @@ from scipy.spatial.transform import Slerp
 
 import weldx.transformations as tf
 from weldx.constants import WELDX_QUANTITY as Q_
+from weldx.constants import WELDX_UNIT_REGISTRY as ureg
 from weldx.core import MathematicalExpression, TimeSeries
+
+
+def ureg_check_class(dimensionalities):
+    """
+    Decorate class __init__ function with pint check().
+
+    Parameters
+    ----------
+    dimensionalities: tuple
+        Tuple of dimensionalities to check class init parameters against.
+
+    Returns
+    -------
+
+    """
+
+    def inner_decorator(original_class,):
+        # Make copy of original __init__, so we can call it without recursion
+        orig_init = original_class.__init__
+
+        # apply pint check decorator
+        new_init = ureg.check(None, *dimensionalities)(orig_init)
+
+        # set new init
+        original_class.__init__ = new_init  # Set the class' __init__ to the new one
+        return original_class
+
+    return inner_decorator
 
 
 def _sine(

--- a/weldx/utility.py
+++ b/weldx/utility.py
@@ -20,14 +20,28 @@ from weldx.constants import WELDX_UNIT_REGISTRY as ureg
 from weldx.core import MathematicalExpression, TimeSeries
 
 
-def ureg_check_class(*dimensionalities):
-    """Decorate class __init__ function with pint.ureg.check().
+def ureg_check_class(*args):
+    """Decorate class :code:`__init__` function with `pint.UnitRegistry.check`.
+
+    Useful for adding unit checks to classes created with :code:`@dataclass` decorator.
 
     Parameters
     ----------
-    dimensionalities: tuple
-        Tuple of dimensionalities to check class init parameters against.
+    args: str or pint.util.UnitsContainer or None
+        Dimensions of each of the input arguments.
+        Use :code:`None` to skip argument conversion.
 
+    Returns
+    -------
+    type
+        The class with unit checks added to its :code:`__init__` function.
+
+    Raises
+    ------
+    TypeError
+        If number of given dimensions does not match the number of function parameters.
+    ValueError
+        If the any of the provided dimensions cannot be parsed as a dimension.
 
     Examples
     --------
@@ -48,7 +62,7 @@ def ureg_check_class(*dimensionalities):
         orig_init = original_class.__init__
 
         # apply pint check decorator
-        new_init = ureg.check(None, *dimensionalities)(orig_init)
+        new_init = ureg.check(None, *args)(orig_init)
 
         # set new init
         original_class.__init__ = new_init  # Set the class' __init__ to the new one

--- a/weldx/utility.py
+++ b/weldx/utility.py
@@ -45,7 +45,7 @@ def ureg_check_class(*args):
 
     Examples
     --------
-    A simple dataclass cloud look like this::
+    A simple dataclass could look like this::
 
         @ureg_check_dataclass("[length]","[time]")
         @dataclass

--- a/weldx/utility.py
+++ b/weldx/utility.py
@@ -20,17 +20,26 @@ from weldx.constants import WELDX_UNIT_REGISTRY as ureg
 from weldx.core import MathematicalExpression, TimeSeries
 
 
-def ureg_check_class(dimensionalities):
-    """
-    Decorate class __init__ function with pint check().
+def ureg_check_class(*dimensionalities):
+    """Decorate class __init__ function with pint.ureg.check().
 
     Parameters
     ----------
     dimensionalities: tuple
         Tuple of dimensionalities to check class init parameters against.
 
-    Returns
-    -------
+
+    Examples
+    --------
+    A simple dataclass cloud look like this::
+
+        @ureg_check_dataclass("[length]","[time]")
+        @dataclass
+        class A:
+            a: pint.Quantity
+            b: pint.Quantity
+
+        A(Q_(3,"mm"),Q_(3,"s"))
 
     """
 

--- a/weldx/utility.py
+++ b/weldx/utility.py
@@ -47,7 +47,7 @@ def ureg_check_class(*args):
     --------
     A simple dataclass could look like this::
 
-        @ureg_check_dataclass("[length]","[time]")
+        @ureg_check_class("[length]","[time]")
         @dataclass
         class A:
             a: pint.Quantity


### PR DESCRIPTION
## Changes
Add a decorator that enables pint dimension checks for `@dataclass` objects

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
