### PR TITLE
Trigger binder build

### DIFF
--- a/.github/workflows/trigger_binder_build.yml
+++ b/.github/workflows/trigger_binder_build.yml
@@ -1,8 +1,8 @@
-name: 'Trigger-Binder-build'
+name: trigger binder build
 on:
   push:
     branches:
-      - 185_trigger_binder_build
+      - master
 
 jobs:
   trigger-binder-build:

--- a/.github/workflows/trigger_binder_build.yml
+++ b/.github/workflows/trigger_binder_build.yml
@@ -1,0 +1,17 @@
+name: 'Trigger-Binder-build'
+on:
+  push:
+    branches:
+      - 185_trigger_binder_build
+
+jobs:
+  trigger-binder-build:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: s-weigand/trigger-mybinder-build@v1
+        with:
+          target-repo: BAMWelDX/weldx
+          service-name: gh
+          target-state: 185_trigger_binder_build
+          use-default-build-servers: true
+          debug: true

--- a/.github/workflows/trigger_binder_build.yml
+++ b/.github/workflows/trigger_binder_build.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           target-repo: BAMWelDX/weldx
           service-name: gh
-          target-state: 185_trigger_binder_build
+          target-state: master
           use-default-build-servers: true
-          debug: true
+          debug: false


### PR DESCRIPTION
## Changes
Adds a Github action that automatically triggers a binder build for the master branch

## Related Issues
Closes #185

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
