### PR TITLE
add default metadata attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release Notes
 
 ## 0.2.3 (unreleased)
+### ASDF
+- Added support for serializing generic metadata and userdata attributes for weldx classes. [[#209]](https://github.com/BAMWelDX/weldx/pull/209)
+  - the provisional attribute names are `wx_metadata` and `wx_user`
 
 ## 0.2.2 (30.11.2020)
 ### added

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -10,6 +10,7 @@ The welding example tutorials provide an overview of common welding related task
     :maxdepth: 1
 
     tutorials/welding_example_01_basics
+    tutorials/custom_metadata
     tutorials/groove_types_01
     tutorials/measurement_example
     tutorials/welding_example_02_weaving

--- a/tests/asdf_tests/test_asdf_core.py
+++ b/tests/asdf_tests/test_asdf_core.py
@@ -380,6 +380,7 @@ def test_coordinate_system_manager_time_dependencies(
     "ts",
     [
         TimeSeries(Q_(42, "m")),
+        TimeSeries(Q_(42.0, "m")),
         TimeSeries(Q_([42, 23, 12], "m"), time=pd.TimedeltaIndex([0, 2, 4])),
         TimeSeries(Q_([42, 23, 12], "m"), time=pd.TimedeltaIndex([0, 2, 5])),
         TimeSeries(ME("a*t+b", parameters={"a": Q_(2, "1/s"), "b": Q_(5, "")})),

--- a/tests/asdf_tests/test_asdf_types.py
+++ b/tests/asdf_tests/test_asdf_types.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from weldx.asdf.types import META_ATTR, USER_ATTR
+from weldx.asdf.utils import _write_read_buffer
+from weldx.measurement import Error
+
+
+def test_meta_attr():
+    e = Error(3.0)
+
+    ts = pd.Timestamp("2020-01-01")
+    setattr(ts, META_ATTR, {"name": "Timestamp"})
+
+    setattr(e, META_ATTR, {"ts": ts})
+    setattr(e, USER_ATTR, {"description": "user info"})
+
+    tree = {"Error": e}
+
+    data = _write_read_buffer(tree)
+
+    e2 = data["Error"]
+
+    assert e2 == e
+    assert getattr(e2, META_ATTR) == getattr(e, META_ATTR)
+    assert getattr(e2, USER_ATTR) == getattr(e, USER_ATTR)
+    assert getattr(getattr(e2, META_ATTR)["ts"], META_ATTR) == getattr(ts, META_ATTR)

--- a/tutorials/custom_metadata.ipynb
+++ b/tutorials/custom_metadata.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Adding custom meta-data\n",
-    "It is possible to attach and store arbitrary meta-data to WelDX objects as python attributes.\n",
+    "# Adding custom metadata\n",
+    "It is possible to attach and store arbitrary metadata to WelDX objects as python attributes.\n",
     "The WelDX API reserves the attribute names `wx_metadata` and `wx_user` for these use cases.\n",
     "\n",
     "The `wx_metadata` field is intended for additional information that might be required as part of a custom Quality Standard. The `wx_user` attribute is intended to add any user data and should only be used for additional information that will not get accessed by the API. \n",
     "\n",
     "## A small example\n",
-    "Let's say we want to use meta-data to add a custom information to a current-sensor used during a welding experiment. As an example we want to add a timestamp to indicate when the sensor was last calibrated."
+    "Let's say we want to use metadata to add a custom information to a current-sensor used during a welding experiment. As an example we want to add a timestamp to indicate when the sensor was last calibrated."
    ]
   },
   {
@@ -48,11 +48,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we want to add the timestamp of the last time the sensor was calibrated as additional meta-data. To do this we simple assign a new `.wx_metadata` attribute to the sensor. We will also add a small personal note to `wx_user`.\n",
+    "Now we want to add the timestamp of the last time the sensor was calibrated as additional metadata. To do this we simple assign a new `.wx_metadata` attribute to the sensor. We will also add a small personal note to `wx_user`.\n",
     "\n",
-    "<div class=\"alert alert-block alert-info\"><b>Note:\n",
-    "    By convention the meta-data fields should be python dictionaries.\n",
-    "</b>"
+    "*Note: By convention the metadata fields should be python dictionaries.*"
    ]
   },
   {
@@ -71,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's look at the ASDF file contents with our meta-data:"
+    "Now let's look at the ASDF file contents with our metadata:"
    ]
   },
   {
@@ -90,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, our custom meta-data gets serialized into the ASDF tree:\n",
+    "As we can see, our custom metadata gets serialized into the ASDF tree:\n",
     "```yaml\n",
     "wx_metadata:\n",
     "    calibration: !<tag:weldx.bam.de:weldx/time/timestamp-1.0.0> {value: '2020-06-01T00:00:00'}\n",

--- a/tutorials/custom_metadata.ipynb
+++ b/tutorials/custom_metadata.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Adding custom meta-data\n",
+    "It is possible to attach and store arbitrary meta-data to WelDX objects as python attributes.\n",
+    "The WelDX API reserves the attribute names `wx_metadata` and `wx_user` for these use cases.\n",
+    "\n",
+    "The `wx_metadata` field is intended for additional information that might be required as part of a custom Quality Standard. The `wx_user` attribute is intended to add any user data and should only be used for additional information that will not get accessed by the API. \n",
+    "\n",
+    "## A small example\n",
+    "Let's say we want to use meta-data to add a custom information to a current-sensor used during a welding experiment. As an example we want to add a timestamp to indicate when the sensor was last calibrated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# if the package is not installed in your python environment, run this to execute the notebook directly from inside the GitHub repository\n",
+    "%cd -q .."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by by creating the sensor object as a `GenericEquipment`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weldx.measurement import GenericEquipment\n",
+    "\n",
+    "HKS_sensor = GenericEquipment(name=\"HKS P1000-S3\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we want to add the timestamp of the last time the sensor was calibrated as additional meta-data. To do this we simple assign a new `.wx_metadata` attribute to the sensor. We will also add a small personal note to `wx_user`.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\"><b>Note:\n",
+    "    By convention the meta-data fields should be python dictionaries.\n",
+    "</b> \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "HKS_sensor.wx_metadata = {\"calibration\" : pd.Timestamp(\"2020-06-01\")}\n",
+    "HKS_sensor.wx_user = {\"notes\":[\"wallmounted\", \"The cable seems to be a bit loose.\"]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's look at the ASDF file contents with our meta-data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weldx.asdf.utils import _write_buffer, notebook_fileprinter\n",
+    "\n",
+    "buffer = _write_buffer({\"sensor\" : HKS_sensor})\n",
+    "notebook_fileprinter(buffer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, our custom meta-data gets serialized into the ASDF tree:\n",
+    "```yaml\n",
+    "wx_metadata:\n",
+    "    calibration: !<tag:weldx.bam.de:weldx/time/timestamp-1.0.0> {value: '2020-06-01T00:00:00'}\n",
+    "  wx_user:\n",
+    "    notes: [wallmounted, The cable seems to be a bit loose.]\n",
+    "```\n",
+    "Let's check if we keep the information upon reading the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weldx.asdf.utils import _read_buffer\n",
+    "\n",
+    "data = _read_buffer(buffer)\n",
+    "display(data[\"sensor\"].wx_metadata)\n",
+    "display(data[\"sensor\"].wx_user)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "weldx",
+   "language": "python",
+   "name": "weldx"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/custom_metadata.ipynb
+++ b/tutorials/custom_metadata.ipynb
@@ -52,8 +52,7 @@
     "\n",
     "<div class=\"alert alert-block alert-info\"><b>Note:\n",
     "    By convention the meta-data fields should be python dictionaries.\n",
-    "</b> \n",
-    "\n"
+    "</b>"
    ]
   },
   {
@@ -64,8 +63,8 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "HKS_sensor.wx_metadata = {\"calibration\" : pd.Timestamp(\"2020-06-01\")}\n",
-    "HKS_sensor.wx_user = {\"notes\":[\"wallmounted\", \"The cable seems to be a bit loose.\"]}"
+    "HKS_sensor.wx_metadata = {\"calibration\": pd.Timestamp(\"2020-06-01\")}\n",
+    "HKS_sensor.wx_user = {\"notes\": [\"wallmounted\", \"The cable seems to be a bit loose.\"]}"
    ]
   },
   {
@@ -83,7 +82,7 @@
    "source": [
     "from weldx.asdf.utils import _write_buffer, notebook_fileprinter\n",
     "\n",
-    "buffer = _write_buffer({\"sensor\" : HKS_sensor})\n",
+    "buffer = _write_buffer({\"sensor\": HKS_sensor})\n",
     "notebook_fileprinter(buffer)"
    ]
   },

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/base_metal-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/base_metal-1.0.0.yaml
@@ -95,5 +95,4 @@ properties:
 required: [common_name, product_form, thickness]
 propertyOrder: [common_name, m_number, group_number, product_form, thickness, diameter, specification_number, specification_version, specification_organization, UNS_number, CAS_number, heat_lot_identification, composition, manufacturing_history, service_history, applied_coating_specification]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/connection-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/connection-1.0.0.yaml
@@ -73,5 +73,4 @@ properties:
 required: [joint_type, weld_type, joint_penetration, weld_details]
 propertyOrder: [joint_type, weld_type, joint_penetration, weld_details]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/joint_penetration-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/joint_penetration-1.0.0.yaml
@@ -58,5 +58,4 @@ properties:
 required: [complete_or_partial, root_penetration]
 propertyOrder: [complete_or_partial, root_penetration, groove_weld_size, incomplete_joint_penetration, weld_size, weld_size_E1, weld_size_E2, depth_of_fusion]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/sub_assembly-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/sub_assembly-1.0.0.yaml
@@ -27,5 +27,4 @@ properties:
 required: [workpiece, connection]
 propertyOrder: [workpiece, connection]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weld_details-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weld_details-1.0.0.yaml
@@ -32,5 +32,4 @@ properties:
 required: [joint_design, weld_sizes, number_of_passes]
 propertyOrder: [joint_design, weld_sizes, number_of_passes]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weldment-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weldment-1.0.0.yaml
@@ -22,5 +22,4 @@ properties:
 required: [sub_assembly]
 propertyOrder: [sub_assembly]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/workpiece-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/workpiece-1.0.0.yaml
@@ -23,5 +23,4 @@ properties:
 required: [geometry]
 propertyOrder: [geometry]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/arc_welding_process-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/arc_welding_process-1.0.0.yaml
@@ -54,5 +54,4 @@ properties:
 required: [name, abbreviation]
 propertyOrder: [name, abbreviation]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
@@ -31,5 +31,4 @@ properties:
 required: [gas_chemical_name, gas_percentage]
 propertyOrder: [gas_chemical_name, gas_percentage]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-1.0.0.yaml
@@ -60,5 +60,4 @@ properties:
 required: [use_torch_shielding_gas, torch_shielding_gas, torch_shielding_gas_flowrate]
 propertyOrder: [use_torch_shielding_gas, torch_shielding_gas, torch_shielding_gas_flowrate, use_backing_gas, backing_gas, backing_gas_flowrate, use_trailing_gas, trailing_shielding_gas, trailing_shielding_gas_flowrate]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_type-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_type-1.0.0.yaml
@@ -32,5 +32,4 @@ properties:
 required: [gas_component, common_name]
 propertyOrder: [gas_component, common_name, designation]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
@@ -29,8 +29,5 @@ properties:
 
 required: [attributes, coordinates, data]
 propertyOrder: [attributes, coordinates, data]
-
-
-
 flowStyle: block
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
@@ -33,5 +33,4 @@ propertyOrder: [attributes, coordinates, data]
 
 
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/dataset-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/dataset-1.0.0.yaml
@@ -38,5 +38,4 @@ properties:
 required: [dimensions, coordinates, variables]
 propertyOrder: [attributes, dimensions, coordinates, variables]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/dimension-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/dimension-1.0.0.yaml
@@ -24,5 +24,4 @@ properties:
 required: [name, length]
 propertyOrder: [name, length]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
@@ -21,5 +21,4 @@ properties:
 required: [expression]
 propertyOrder: [expression, parameters]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
@@ -24,6 +24,7 @@ oneOf:
           Unit of the data.
         type: string
     required: [values, unit]
+    additionalProperties: false
 
   - type: object
     description: |
@@ -42,6 +43,7 @@ oneOf:
           (optional) Resulting shape of the data when the expression is evaluated.
         type: array
     required: [values, unit]
+    additionalProperties: false
 
   - type: object
     description: |
@@ -74,8 +76,7 @@ oneOf:
       time: [t]
       values: [t, ...]
     required: [time, unit, shape, interpolation, values]
-
-
+    additionalProperties: false
 
 propertyOrder: [time, unit, shape, interpolation, values]
 flowStyle: block

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
@@ -24,7 +24,6 @@ oneOf:
           Unit of the data.
         type: string
     required: [values, unit]
-    additionalProperties: false
 
   - type: object
     description: |
@@ -43,7 +42,6 @@ oneOf:
           (optional) Resulting shape of the data when the expression is evaluated.
         type: array
     required: [values, unit]
-    additionalProperties: false
 
   - type: object
     description: |
@@ -76,7 +74,6 @@ oneOf:
       time: [t]
       values: [t, ...]
     required: [time, unit, shape, interpolation, values]
-    additionalProperties: false
 
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
@@ -13,24 +13,23 @@ oneOf:
     description: |
       Implementation for constant values.
     properties:
-      values:
+      value:
         description: |
           Number or n-dimensional array that is constant in time.
-        oneOf:
+        anyOf:
           - type: number
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       unit:
         description: |
           Unit of the data.
         type: string
-    required: [values, unit]
-    additionalProperties: false
+    required: [value, unit]
 
   - type: object
     description: |
       Implementation for expressions.
     properties:
-      values:
+      expression:
         description: |
           A mathematical expression that describes the time dependent behaviour.
         tag: "tag:weldx.bam.de:weldx/core/mathematical_expression-1.0.0"
@@ -42,8 +41,7 @@ oneOf:
         description: |
           (optional) Resulting shape of the data when the expression is evaluated.
         type: array
-    required: [values, unit]
-    additionalProperties: false
+    required: [expression, unit]
 
   - type: object
     description: |
@@ -76,8 +74,7 @@ oneOf:
       time: [t]
       values: [t, ...]
     required: [time, unit, shape, interpolation, values]
-    additionalProperties: false
 
-propertyOrder: [time, unit, shape, interpolation, values]
+propertyOrder: [expression, values, time, unit, shape, interpolation, values]
 flowStyle: block
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy-1.0.0.yaml
@@ -50,6 +50,4 @@ properties:
 propertyOrder: [name, root_system_name, reference_time, subsystems, subsystem_data,  coordinate_systems]
 required: [name, root_system_name, coordinate_systems]
 flowStyle: block
-additionalProperties: false
-
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy_subsystem-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy_subsystem-1.0.0.yaml
@@ -46,6 +46,4 @@ properties:
 
 propertyOrder: [name, parent_system, root_cs, members, subsystems]
 flowStyle: block
-additionalProperties: false
-
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_transformation-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_transformation-1.0.0.yaml
@@ -26,6 +26,4 @@ properties:
 propertyOrder: [name, reference_system, transformation]
 required: [name, reference_system, transformation]
 flowStyle: block
-additionalProperties: false
-
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-1.0.0.yaml
@@ -36,5 +36,4 @@ wx_shape:
 
 propertyOrder: [reference_time, time, orientations, coordinates]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
@@ -36,5 +36,4 @@ properties:
 required: [name, dimensions, dtype, data]
 propertyOrder: [name, dimensions, dtype, unit, data]
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/equipment/generic_equipment-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/equipment/generic_equipment-1.0.0.yaml
@@ -26,5 +26,4 @@ propertyOrder: [name, sources, data_transformations]
 required: [name]
 
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data-1.0.0.yaml
@@ -20,5 +20,4 @@ propertyOrder: [name, data]
 required: [data]
 
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data_transformation-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data_transformation-1.0.0.yaml
@@ -28,5 +28,4 @@ required: [name, input_signal, output_signal]
 propertyOrder: [name, input_signal, output_signal, error, func]
 
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/error-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/error-1.0.0.yaml
@@ -21,5 +21,4 @@ properties:
 required: [deviation]
 
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement-1.0.0.yaml
@@ -20,8 +20,5 @@ properties:
 
 propertyOrder: [name, data, measurement_chain]
 required: [name, data]
-
-
-
 flowStyle: block
-additionalProperties: false
+...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement_chain-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement_chain-1.0.0.yaml
@@ -20,8 +20,5 @@ properties:
 
 propertyOrder: [name, data_source, data_processors]
 required: [name, data_source]
-
-
-
 flowStyle: block
-additionalProperties: false
+...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/signal-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/signal-1.0.0.yaml
@@ -18,7 +18,5 @@ properties:
 
 propertyOrder: [signal_type, unit, data]
 required: [signal_type, unit]
-
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/source-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/source-1.0.0.yaml
@@ -17,9 +17,5 @@ properties:
 
 required: [name, output_signal]
 propertyOrder: [name, output_signal, error]
-
-
-
 flowStyle: block
-additionalProperties: false
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/datetimeindex-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/datetimeindex-1.0.0.yaml
@@ -58,7 +58,6 @@ oneOf:
 
     required: [values]
     propertyOrder: [values, start, end, freq, min, max]
-    additionalProperties: false
 
   - type: object
     properties:
@@ -75,7 +74,6 @@ oneOf:
 
     required: [start, end, freq]
     propertyOrder: [start, end, freq, min, max]
-    additionalProperties: false
 ...
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedelta-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedelta-1.0.0.yaml
@@ -16,5 +16,4 @@ properties:
 
 required: [value]
 propertyOrder: [value]
-additionalProperties: true
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedeltaindex-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedeltaindex-1.0.0.yaml
@@ -58,7 +58,6 @@ oneOf:
 
     required: [values]
     propertyOrder: [values, start, end, freq, min, max]
-    additionalProperties: false
 
   - type: object
     properties:
@@ -75,8 +74,6 @@ oneOf:
 
     required: [start, end, freq]
     propertyOrder: [start, end, freq, min, max]
-    additionalProperties: false
-
 ...
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/timestamp-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/timestamp-1.0.0.yaml
@@ -23,5 +23,4 @@ properties:
 
 required: [value]
 propertyOrder: [value, tz]
-additionalProperties: true
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/unit/dimension-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/unit/dimension-1.0.0.yaml
@@ -63,5 +63,4 @@ properties:
       - magnetic_dipole
 
 required: [name]
-additionalProperties: false
 ...

--- a/weldx/asdf/tags/weldx/core/time_series.py
+++ b/weldx/asdf/tags/weldx/core/time_series.py
@@ -5,7 +5,7 @@ import pint
 
 from weldx.asdf.types import WeldxType
 from weldx.constants import WELDX_QUANTITY as Q_
-from weldx.core import MathematicalExpression, TimeSeries
+from weldx.core import TimeSeries
 
 
 class TimeSeriesTypeASDF(WeldxType):

--- a/weldx/asdf/tags/weldx/core/time_series.py
+++ b/weldx/asdf/tags/weldx/core/time_series.py
@@ -39,10 +39,10 @@ class TimeSeriesTypeASDF(WeldxType):
         """
 
         if isinstance(node.data, pint.Quantity):
-            if node.shape == tuple([1]):
+            if node.shape == tuple([1]):  # constant
                 return {
                     "unit": str(node.units),
-                    "values": node.data.magnitude[0],
+                    "value": node.data.magnitude[0],
                 }
             else:
                 return {
@@ -52,7 +52,7 @@ class TimeSeriesTypeASDF(WeldxType):
                     "interpolation": node.interpolation,
                     "values": node.data.magnitude,
                 }
-        return {"values": node.data, "unit": str(node.units), "shape": node.shape}
+        return {"expression": node.data, "unit": str(node.units), "shape": node.shape}
 
     @classmethod
     def from_tree(cls, tree, ctx):
@@ -73,14 +73,13 @@ class TimeSeriesTypeASDF(WeldxType):
             An instance of the 'weldx.core.TimeSeries' type.
 
         """
-        if not isinstance(tree["values"], MathematicalExpression):
-            if "time" in tree:
-                time = tree["time"]
-                interpolation = tree["interpolation"]
-            else:
-                time = None
-                interpolation = None
-            values = Q_(np.asarray(tree["values"]), tree["unit"])
+        if "value" in tree:  # constant
+            values = Q_(np.asarray(tree["value"]), tree["unit"])
+            return TimeSeries(values)
+        elif "values" in tree:
+            time = tree["time"]
+            interpolation = tree["interpolation"]
+            values = Q_(tree["values"], tree["unit"])
             return TimeSeries(values, time, interpolation)
 
-        return TimeSeries(tree["values"])
+        return TimeSeries(tree["expression"])  # mathexpression

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -43,11 +43,15 @@ def from_tree_metadata(func):
     @functools.wraps(func)
     def from_tree_wrapped(cls, tree: dict, ctx):  # need cls for classmethod
         """Call default from_tree method and add metadata attributes."""
-        obj = func(tree, ctx)
+        meta_dict = {}
         for key in [META_ATTR, USER_ATTR]:
-            value = tree.get(key, None)
+            value = tree.pop(key, None)
             if value:
-                setattr(obj, key, value)
+                meta_dict[key] = value
+
+        obj = func(tree, ctx)
+        for key, value in meta_dict.items():
+            setattr(obj, key, value)
         return obj
 
     return from_tree_wrapped


### PR DESCRIPTION
## Changes
basically the simplest way I could think of to always serialize `metadata` attributes of any class (if it exists)

short example tutorial [here](https://weldx--209.org.readthedocs.build/en/209/tutorials/custom_metadata.html) @AndreasPittner 

## ToDos
- [x] wrap `from_tree` to read metadata field
- [x] remove `additionalProperties` from all schemas by default
- [ ] I have a feeling it would be safer to wrap `to_tree_tagged` instead of `to_tree` since this is the final function that produces the `TaggedObject`
I think we can skip this for now but may have to be careful for classes that implement their own `to/from_tree_tagged`

## Related Issues
Closes #205 

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
