### PR TITLE
pass tuple to lambdify in MathematicalExpression

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: weldx
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   - python=3.7
   - setuptools_scm

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -34,7 +34,7 @@ class MathematicalExpression:
             expression = sympy.sympify(expression)
         self._expression = expression
         self.function = sympy.lambdify(
-            self._expression.free_symbols, self._expression, "numpy"
+            tuple(self._expression.free_symbols), self._expression, "numpy"
         )
         self._parameters = {}
         if parameters is not None:


### PR DESCRIPTION
## Changes
- pass variable names as tuple to `sympy.lambdify` (was `set` before)
- set conda-forge as primary env channel (should make docs/tests more consistent and up to date)

## Related Issues
Closes #210 

## Checks
- [ ] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
