### PR TITLE
CI speedup mamba/pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           activate-environment: build_env
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          channels: conda-forge, defaults
           mamba-version: "*"
 
       - name: conda info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           activate-environment: build_env
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          mamba-version: "*"
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           environment-file: ./conda.recipe/build_env.yml
           activate-environment: build_env
           auto-activate-base: false

--- a/.github/workflows/clean_notebooks.yml
+++ b/.github/workflows/clean_notebooks.yml
@@ -3,7 +3,7 @@ name: check notebooks
 on:
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   check:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           environment-file: ./environment.yml
           activate-environment: weldx
           auto-activate-base: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,7 @@ jobs:
           activate-environment: weldx
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          channels: conda-forge, defaults
           mamba-version: "*"
 
       - name: conda info

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,7 @@ jobs:
           activate-environment: weldx
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          mamba-version: "*"
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        py: ['3.7', '3.8', '3.9']
+        py: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: ${{ matrix.py }}
 
       - uses: actions/cache@v2
-        if: startsWith(runner.os, 'ubuntu')
+        if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        py: ['3.7']
+        py: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,3 +48,23 @@ jobs:
 
       - name: codecov.io
         uses: codecov/codecov-action@v1
+
+  pytest_pip:
+    name: pytest pip
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
+        py: [ '3.7', '3.8' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py }}
+      - name: pip installs
+        run: |
+          pip install .
+      - name: run pytest
+        run: |
+          pytest --runslow
+          coverage xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,7 @@ jobs:
           activate-environment: weldx
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          channels: conda-forge, defaults
           mamba-version: "*"
 
       - name: conda info

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        py: [ '3.7' ]
+        py: ['3.7']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,7 @@ jobs:
           activate-environment: weldx
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          mamba-version: "*"
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,6 +63,7 @@ jobs:
           python-version: ${{ matrix.py }}
       - name: pip installs
         run: |
+          pip install pytest pytest-cov setuptools_scm
           pip install .
       - name: run pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,12 +25,11 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           environment-file: ./environment.yml
           activate-environment: weldx
           auto-activate-base: false
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          channels: conda-forge, defaults
+          channels: conda-forge,defaults
           mamba-version: "*"
 
       - name: conda info

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,61 +6,39 @@ jobs:
     name: pytest
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if ./environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./environment.yml') }}
-
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          environment-file: ./environment.yml
-          activate-environment: weldx
-          auto-activate-base: false
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          channels: conda-forge,defaults
-          mamba-version: "*"
-
-      - name: conda info
-        shell: bash -l {0}
-        run: conda info
-
-      - name: conda list
-        shell: bash -l {0}
-        run: conda list
-
-      - name: pytest
-        shell: bash -l {0}
-        run: |
-          pytest --runslow
-          coverage xml
-
-      - name: codecov.io
-        uses: codecov/codecov-action@v1
-
-  pytest_pip:
-    name: pytest pip
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        py: [ '3.7', '3.8' ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        py: [ '3.7' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py }}
+
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'ubuntu')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: pip installs
         run: |
           pip install pytest pytest-cov setuptools_scm
@@ -69,3 +47,6 @@ jobs:
         run: |
           pytest --runslow
           coverage xml
+
+      - name: codecov.io
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        py: [ '3.7', '3.8' ]
+        py: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: [ '3.7', '3.8' ]
+        py: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: [ '3.7', '3.8' ]
+        py: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: [ '3.7', '3.8' ]
+        py: ['3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/trigger_binder_build.yml
+++ b/.github/workflows/trigger_binder_build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-binder-build:
-    runs-on: [ubuntu-latest]
+    runs-on: [ ubuntu-latest ]
     steps:
       - uses: s-weigand/trigger-mybinder-build@v1
         with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,7 +22,7 @@ sphinx:
 # Optionally set the version of Python and requirements required to build your docs
 
 conda:
-  environment: environment.yml
+  environment: doc/rtd_environment.yml
 python:
    version: 3.7
    install:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,6 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinxcontrib.bibtex",
     "sphinx_copybutton",
     "sphinx_asdf",
     "numpydoc",

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.7
   - setuptools_scm
   - ipykernel
+  - ipywidgets
   # documentation
   - sphinx
   - recommonmark

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -1,10 +1,10 @@
-name: weldx
 channels:
   - conda-forge
   - defaults
 dependencies:
   - python=3.7
   - setuptools_scm
+  - ipykernel
   # documentation
   - sphinx
   - recommonmark

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -1,0 +1,19 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - setuptools_scm
+  # documentation
+  - sphinx
+  - recommonmark
+  - sphinxcontrib-napoleon
+  - nbsphinx
+  - sphinx-copybutton
+  - pydata-sphinx-theme
+  - numpydoc>=0.5
+  - sphinx-autodoc-typehints
+  # pip packages
+  - pip
+  - pip:
+    - git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -1,3 +1,4 @@
+name: weldx
 channels:
   - conda-forge
   - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,6 @@ dependencies:
   - sphinxcontrib-napoleon
   - nbsphinx
   - sphinx-copybutton
-  - sphinxcontrib-bibtex
   - pydata-sphinx-theme
   - numpydoc>=0.5
   - sphinx-autodoc-typehints

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ install_requires =
     Jinja2 >=2.11
     networkx >=2
     matplotlib >=3
+    ipywidgets
 include_package_data = True
 
 [options.entry_points]


### PR DESCRIPTION
## Changes
I ended up adding a few improvements to speed up the pipelines:
- pytest setup installs via pip (installs ~1-2 min on all OS)
- pytests runs on python matrix (currently 3.7 & 3.8)
- skip the auto conda update step (one less time solving conda envs)
- use mamba for conda environment setup in remaining conda actions (a little bit faster)
- ReadTheDocs now has it's own (stripped down) environment file `doc/rtd_environment.yml`. Conda build time improved from >400s to 150s 🥳 . Pip installs only increased from 40s to 70s so quite a net benefit here
- I added `ipywidgets` to the requirement in `setup.cfg` since some tutorials need them (CSM). We should keep this in mind once we split the packages further

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
