### PR TITLE
don't store time dependent LCS coordinates inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - set minimum Python version to 3.7 [[#220]](https://github.com/BAMWelDX/weldx/pull/220)
 
 ### fixes
-- don't inline time dependent `LCS.coordinates` [[#220]](https://github.com/BAMWelDX/weldx/pull/220)
+- don't inline time dependent `LCS.coordinates` [[#222]](https://github.com/BAMWelDX/weldx/pull/222)
 
 ## 0.2.2 (30.11.2020)
 ### added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - set `conda-forge` as primary channel in `environment.yaml` and `build_env.yaml` [[#214]](https://github.com/BAMWelDX/weldx/pull/214)
 - set minimum Python version to 3.7 [[#220]](https://github.com/BAMWelDX/weldx/pull/220)
 
+### fixes
+- don't inline time dependent `LCS.coordinates` [[#220]](https://github.com/BAMWelDX/weldx/pull/220)
+
 ## 0.2.2 (30.11.2020)
 ### added
 - Added `weldx.utility.ureg_check_class` class decorator to enable `pint` dimensionality checks with `@dataclass`. [[#179]](https://github.com/BAMWelDX/weldx/pull/179)

--- a/weldx/asdf/tags/weldx/core/transformations/local_coordinate_system.py
+++ b/weldx/asdf/tags/weldx/core/transformations/local_coordinate_system.py
@@ -53,10 +53,11 @@ class LocalCoordinateSystemASDF(WeldxType):
             coordinates = Variable(
                 "coordinates", node.coordinates.dims, node.coordinates.data
             )
-            if isinstance(coordinates.data, pint.Quantity):
-                ctx.set_array_storage(coordinates.data.magnitude, "inline")
-            else:
-                ctx.set_array_storage(coordinates.data, "inline")
+            if "time" not in node.coordinates.coords:
+                if isinstance(coordinates.data, pint.Quantity):
+                    ctx.set_array_storage(coordinates.data.magnitude, "inline")
+                else:
+                    ctx.set_array_storage(coordinates.data, "inline")
             tree["coordinates"] = coordinates
 
         if "time" in node.dataset.coords:


### PR DESCRIPTION
## Changes
- time dependent LCS coords no longer stored inline

## Related Issues
Closes # (add issue numbers)

## Checks
- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
