### PR TITLE
[ci/gha] use pytest-xdist to use multiple cores

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,5 @@
 name: pytest
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: pip installs
         run: |
-          pip install pytest pytest-cov setuptools_scm
+          pip install pytest pytest-cov pytest-xdist setuptools_scm
           pip install -e .
       - name: run pytest
         run: |
-          pytest --runslow
+          pytest --runslow -n2
           echo "Exited with '$?'"
           coverage xml
 

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,5 +1,5 @@
 name: static analysis
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pydocstyle:


### PR DESCRIPTION
## Changes

Use xdist to utilize multiple cpu cores on Github actions containers. Tested locally, that coverage reports are the same. Without slow tests the execution time went down from 128s to 70s.