### PR TITLE
modify CSM merge for non datetime subsytems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - refactor the `transformations` and `visualization` module into smaller files [[#247]](https://github.com/BAMWelDX/weldx/pull/247)
 - refactor `weldx.utility` into `weldx.util` [[#247]](https://github.com/BAMWelDX/weldx/pull/247)
 - refactor `weldx.asdf.utils` into `weldx.asdf.util` [[#247]](https://github.com/BAMWelDX/weldx/pull/247)
+- it is now allowed to merge a time-dependent `timedelta` subsystem into another `CSM` instance if the parent instance has set an explicit reference time [[#268]](https://github.com/BAMWelDX/weldx/pull/268)
 
 
 ### fixes
@@ -70,6 +71,7 @@
 - update some documentation formatting and links [[#247]](https://github.com/BAMWelDX/weldx/pull/247)
 - fix `wx_shape` validation for scalar `Quantity` and `TimeSeries`
   objects [[#256]](https://github.com/BAMWelDX/weldx/pull/256)
+- fix a case where `CSM.time_union()` would return with mixed `DateTimeIndex` and `TimeDeltaIndex` types [[#268]](https://github.com/BAMWelDX/weldx/pull/268)
 
 ### dependencies
 

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -2962,13 +2962,13 @@ class TestCoordinateSystemManager:
             (None, "01", False, True, False),
             # parent static
             (None, None, True, False, False),
-            ("01", None, True, False, True),
+            ("01", None, True, False, False),
             ("01", "01", True, False, False),
             ("01", "03", True, False, True),
             (None, "01", True, False, True),
             # both dynamic
             (None, None, False, False, False),
-            ("01", None, False, False, True),
+            ("01", None, False, False, False),
             ("01", "01", False, False, False),
             ("01", "03", False, False, True),
             (None, "01", False, False, True),

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1866,9 +1866,19 @@ class CoordinateSystemManager:
             return None
 
         time_list = [util.to_pandas_time_index(lcs) for lcs in lcs_list]
-        if self.has_reference_time:
+        reference_time = self.reference_time
+        if self.uses_absolute_times and not reference_time:
+            reference_time = min(
+                [
+                    lcs.reference_time
+                    for lcs in self.lcs_time_dependent
+                    if lcs.reference_time
+                ]
+            )  # there should only be one LCS with reference time in this case but still
+
+        if reference_time:
             time_list = [
-                t + self.reference_time if isinstance(t, pd.TimedeltaIndex) else t
+                t + reference_time if isinstance(t, pd.TimedeltaIndex) else t
                 for t in time_list
             ]
 

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1572,8 +1572,8 @@ class CoordinateSystemManager:
             )
         ):
             raise Exception(
-                "You can only merge subsystems with time dependent coordinate systems"
-                "if the reference times of both `CoordinateSystemManager` instances"
+                "You can only merge subsystems with time dependent coordinate systems "
+                "if the reference times of both `CoordinateSystemManager` instances "
                 "are identical."
             )
 

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1869,19 +1869,9 @@ class CoordinateSystemManager:
             return None
 
         time_list = [util.to_pandas_time_index(lcs) for lcs in lcs_list]
-        reference_time = self.reference_time
-        if self.uses_absolute_times and not reference_time:
-            reference_time = min(
-                [
-                    lcs.reference_time
-                    for lcs in self.lcs_time_dependent
-                    if lcs.reference_time
-                ]
-            )  # there should only be one LCS with reference time in this case but still
-
-        if reference_time:
+        if self.has_reference_time:
             time_list = [
-                t + reference_time if isinstance(t, pd.TimedeltaIndex) else t
+                t + self.reference_time if isinstance(t, pd.TimedeltaIndex) else t
                 for t in time_list
             ]
 

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1560,9 +1560,12 @@ class CoordinateSystemManager:
             instance.
 
         """
-        if (
-            other._number_of_time_dependent_lcs > 0
-            and self.reference_time != other.reference_time
+        if other._number_of_time_dependent_lcs > 0 and (
+            (not self.has_reference_time and other.uses_absolute_times)
+            or (
+                (self.has_reference_time and other.has_reference_time)
+                and (self.reference_time != other.reference_time)
+            )
         ):
             raise Exception(
                 "You can only merge subsystems with time dependent coordinate systems"

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1869,9 +1869,19 @@ class CoordinateSystemManager:
             return None
 
         time_list = [util.to_pandas_time_index(lcs) for lcs in lcs_list]
-        if self.has_reference_time:
+        reference_time = self.reference_time
+        if self.uses_absolute_times and not reference_time:
+            reference_time = min(
+                [
+                    lcs.reference_time
+                    for lcs in self.lcs_time_dependent
+                    if lcs.reference_time
+                ]
+            )
+
+        if reference_time:
             time_list = [
-                t + self.reference_time if isinstance(t, pd.TimedeltaIndex) else t
+                t + reference_time if isinstance(t, pd.TimedeltaIndex) else t
                 for t in time_list
             ]
 

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1561,9 +1561,13 @@ class CoordinateSystemManager:
 
         """
         if other._number_of_time_dependent_lcs > 0 and (
-            (not self.has_reference_time and other.uses_absolute_times)
+            (not self.uses_absolute_times and other.uses_absolute_times)
             or (
-                (self.has_reference_time and other.has_reference_time)
+                (self.uses_absolute_times and not self.has_reference_time)
+                and not other.uses_absolute_times
+            )
+            or (
+                (self.has_reference_time and other.uses_absolute_times)
                 and (self.reference_time != other.reference_time)
             )
         ):


### PR DESCRIPTION
## Changes
- allow time dependent subsystems that don't use absolute times to be merged into CSM instances with a set reference time
- make sure `csm.time_union()` returns correct index type without explicit reference time

## Related Issues

Closes # (add issue numbers)

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [ ] updated doc/
- [x] update example/tutorial notebooks 
