### PR TITLE
Fix a bug in CSM interp_time

### DIFF
--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -3992,7 +3992,7 @@ def test_coordinate_system_manager_interp_time():
         check_coordinate_systems_close(lcs, exp)
         check_coordinate_systems_close(lcs_inv, exp_inv)
 
-        # Related to pull request #INSERT_NUMBER. This assures that interp time works
+        # Related to pull request #275. This assures that interp time works
         # correctly if some coordinate systems have no own reference time, but the CSM
         # does.
         lcs1 = tf.LocalCoordinateSystem(

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -3824,7 +3824,6 @@ def test_coordinate_system_manager_interp_time():
 
     # interp_time -------------------------------
     time_interp = TDI([1, 3, 5, 7, 9], "D")
-    print(csm._reference_time)
     csm_interp = csm.interp_time(time_interp)
 
     assert np.all(csm_interp.time_union() == time_interp)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -3824,6 +3824,7 @@ def test_coordinate_system_manager_interp_time():
 
     # interp_time -------------------------------
     time_interp = TDI([1, 3, 5, 7, 9], "D")
+    print(csm._reference_time)
     csm_interp = csm.interp_time(time_interp)
 
     assert np.all(csm_interp.time_union() == time_interp)
@@ -3990,6 +3991,28 @@ def test_coordinate_system_manager_interp_time():
 
         check_coordinate_systems_close(lcs, exp)
         check_coordinate_systems_close(lcs_inv, exp_inv)
+
+        # Related to pull request #INSERT_NUMBER. This assures that interp time works
+        # correctly if some coordinate systems have no own reference time, but the CSM
+        # does.
+        lcs1 = tf.LocalCoordinateSystem(
+            coordinates=[[1, 0, 0], [2, 0, 0]], time=pd.TimedeltaIndex([1, 2])
+        )
+
+        lcs2 = tf.LocalCoordinateSystem(
+            coordinates=[[1, 0, 0], [2, 0, 0]],
+            time=pd.TimedeltaIndex([1, 2]) + pd.Timestamp("2000-01-03"),
+        )
+
+        csm_1 = tf.CoordinateSystemManager("root", time_ref=pd.Timestamp("2000-01-01"))
+        csm_1.add_cs("lcs2", "root", lcs2)
+
+        csm_2 = tf.CoordinateSystemManager("root")
+        csm_2.add_cs("lcs1", "root", lcs1)
+
+        csm_1.merge(csm_2)
+
+        csm_1.interp_time(csm_1.time_union())
 
 
 def test_coordinate_system_manager_transform_data():

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1514,9 +1514,13 @@ class CoordinateSystemManager:
 
             for edge in affected_edges:
                 if self._graph.edges[edge]["defined"]:
-                    self._graph.edges[edge]["lcs"] = self._graph.edges[edge][
-                        "lcs"
-                    ].interp_time(time, time_ref)
+                    lcs = self._graph.edges[edge]["lcs"]
+                    # this prevents failures when calling lcs.interp_time with reference
+                    # times or DatetimeIndex.
+                    if lcs.reference_time is None and self._reference_time is not None:
+                        lcs.reset_reference_time(self._reference_time)
+                    self._graph.edges[edge]["lcs"] = lcs.interp_time(time, time_ref)
+
             for edge in affected_edges:
                 if not self._graph.edges[edge]["defined"]:
                     self._graph.edges[edge]["lcs"] = self._graph.edges[


### PR DESCRIPTION
## Changes

Before this PR, calling `CoordinateSystemManager.interp_time` with absolute times would fail if the CSM had coordinate systems without a reference time even though the CSM has one.

## Checks

- [x] ~~updated CHANGELOG.md~~
- [x] updated tests
- [x] ~~updated doc/~~
- [x] ~~update example/tutorial notebooks~~
