### PR TITLE
allow inline scalar coordinates/variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## ASDF 2.8
+
+- fix inline array serialization for new 64bit inline limit
+
 ## 0.3.0 (12.03.2021)
 
 ### added

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
@@ -27,7 +27,9 @@ properties:
   data:
     description: |
       An n-dimensional array that contains the data.
-    $ref: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    oneOf:
+      - tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+      - type: number
   unit:
     description: |
       Optional field describing the unit of the data as valid string representation.

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -145,6 +145,8 @@ class VariableTypeASDF(WeldxType):
             data = node.data
         dtype = node.data.dtype.str
         data = cls.convert_time_dtypes(data=data)
+        if not data.shape:  # scalar
+            data = np.asscalar(data)
         tree = {
             "name": node.name,
             "dimensions": node.dimensions,
@@ -176,9 +178,8 @@ class VariableTypeASDF(WeldxType):
 
         """
         dtype = np.dtype(tree["dtype"])
+        data = np.array(tree["data"], dtype=dtype)
         if "unit" in tree:  # convert to pint.Quantity
-            data = Q_(tree["data"].astype(dtype), tree["unit"])
-        else:
-            data = tree["data"].astype(dtype)
+            data = Q_(data, tree["unit"])
 
         return Variable(tree["name"], tree["dimensions"], data)


### PR DESCRIPTION
## Changes
allows to store scalar values as `number` in `variable-1.0.0.yaml`
This is necessary because scalar values like `{'shape': [], 'data': 1409875200000000000, 'datatype': 'int64'}` are not covered by ASDF `ndarray`  (data must be list)

## Related Issues

Closes # (add issue numbers)

## Checks

- [x] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
