### PR TITLE
update single_pass_weld schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.3.1 (unreleased)
+
+### ASDF
+
+- remove the `additionalProperties` restriction
+  from `single_pass_weld-1.0.0.schema.yaml` [[#283]](https://github.com/BAMWelDX/weldx/pull/283)
+
 ## 0.3.0 (12.03.2021)
 
 ### added

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-1.0.0.schema.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-1.0.0.schema.yaml
@@ -136,8 +136,6 @@ properties:
       Metadata container for additional user documentation of the experiment.
     type: object
 required: [equipment,workpiece,measurements,welding_current,welding_voltage,TCP]
-additionalProperties: false
-
 
 examples:
   -


### PR DESCRIPTION
## Changes
remove the `additionalProperties` restriction for the file schema since it seems to interfere with the `asdf_library` and `history` entries sometimes

## Related Issues

## Checks

- [x] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
