### PR TITLE
Add warning if time is dropped in LCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - remove the `additionalProperties` restriction
   from `single_pass_weld-1.0.0.schema.yaml` [[#283]](https://github.com/BAMWelDX/weldx/pull/283)
 
+### fixes
+
+- A warning is now emitted if a `LocalCoordinateSystem` drops a provided time during construction. This usually happens 
+  if the coordinates and orientation only contain a single data point. 
+  [[#285]](https://github.com/BAMWelDX/weldx/pull/285)
+
 ## 0.3.0 (12.03.2021)
 
 ### added

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -601,6 +601,35 @@ class TestLocalCoordinateSystem:
         assert np.all(lcs.datetimeindex == datetime_exp)
         assert np.all(lcs.time_quantity == quantity_exp)
 
+    # test_time_warning ----------------------------------------------------------------
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "coordinates, orientation, time, warning",
+        [
+            (np.zeros(3), np.eye(3, 3), TDI([0, 2], "s"), UserWarning),
+            (np.zeros((2, 3)), np.eye(3, 3), TDI([0, 2], "s"), None),
+            (np.zeros(3), np.eye(3, 3), None, None),
+        ],
+    )
+    def test_time_warning(coordinates, orientation, time, warning):
+        """Test that warning is emitted when time is provided to a static CS.
+
+        Parameters
+        ----------
+        coordinates :
+            Coordinates of the CS
+        orientation :
+            Orientation of the CS
+        time :
+            Provided time
+        warning :
+            Expected warning
+
+        """
+        with pytest.warns(warning):
+            LCS(coordinates=coordinates, orientation=orientation, time=time)
+
     # test_init_time_dsx ---------------------------------------------------------------
 
     @staticmethod

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Union
 
@@ -72,6 +73,14 @@ class LocalCoordinateSystem:
         time, time_ref = build_time_index(time, time_ref)
         orientation = self._build_orientation(orientation, time)
         coordinates = self._build_coordinates(coordinates, time)
+
+        if time is not None and not (
+            "time" in coordinates.coords or "time" in orientation.coords
+        ):
+            warnings.warn(
+                "Neither the coordinates nor the orientation are time dependent. "
+                "Provided time is dropped"
+            )
 
         if construction_checks:
             ut.xr_check_coords(

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -53,7 +53,10 @@ class LocalCoordinateSystem:
         coordinates :
             Coordinates of the origin
         time :
-            Time data for time dependent coordinate systems
+            Time data for time dependent coordinate systems. If the provided coordinates
+            and orientations contain only a single value, the coordinate system is
+            considered to be static and the provided value won't be stored. If this
+            happens, a warning will be emitted.
         time_ref :
             Reference Timestamp to use if time is Timedelta or pint.Quantity.
         construction_checks :


### PR DESCRIPTION
## Changes

The LCS now emits a warning if a provided time parameter is ignored

## Related Issues

Closes #281

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] ~~update example/tutorial notebooks~~
