### PR TITLE
allow integer for timeseries to test for issue #282

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - remove the `additionalProperties` restriction
   from `single_pass_weld-1.0.0.schema.yaml` [[#283]](https://github.com/BAMWelDX/weldx/pull/283)
+- allow scalar `integer` value in `anyOf` of `time_series-1.0.0.yaml` to
+  fix [#282](https://github.com/BAMWelDX/weldx/pull/282) [[#286]](https://github.com/BAMWelDX/weldx/pull/286)
 
 ## 0.3.0 (12.03.2021)
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/time_series-1.0.0.yaml
@@ -18,6 +18,7 @@ oneOf:
           Number or n-dimensional array that is constant in time.
         anyOf:
           - type: number
+          - type: integer
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       unit:
         description: |


### PR DESCRIPTION
## Changes
allows integer values in `TimeSeries` schema in an attempt to fix #282 

## Related Issues
Closes #282 

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
