### PR TITLE
update binder environment for JupyterLab3 and k3d

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,10 +7,10 @@ dependencies:
   - setuptools_scm
   - pip
   # Notebook + Plotting
-  - jupyterlab=2
+  - jupyterlab=3
   - ipykernel
-  - matplotlib=3.3.2
-  - ipympl=0.5.8
-  - nodejs=14
+  - matplotlib
+  - ipympl
+  - nodejs
   - pip:
     - git+https://github.com/BAMWelDX/weldx.git

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Install required matplotlib JupyterLab extensions
-jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager jupyter-matplotlib@0.7.4 k3d --debug
+jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager k3d --debug
 jupyter lab build --minimize=False --debug

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -3,3 +3,5 @@
 # Install required matplotlib JupyterLab extensions
 jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager k3d --debug
 jupyter lab build --minimize=False --debug
+
+python setup.py --version


### PR DESCRIPTION
## Changes
Unpin JupyterLab plugin versions and install k3d extension in binder

Now works with jupyterlab3 and k3d extension 🚀 
