### PR TITLE
replace $ref when tags are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `weldx.util.deprecated` decorator [[#295]](https://github.com/BAMWelDX/weldx/pull/295)
 
+### ASDF
+
+- add validators to `rotation-1.0.0.yaml`
+  & `gas_component-1.0.0.yaml` [[#303]](https://github.com/BAMWelDX/weldx/pull/303)
 
 ## 0.3.1 (21.03.2021)
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/base_metal-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/base_metal-1.0.0.yaml
@@ -33,7 +33,7 @@ properties:
   thickness:
     description: |
       Plate or sheet thickness, if tube, specifies wall thickness.
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   diameter:
     description: |

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/joint_penetration-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/joint_penetration-1.0.0.yaml
@@ -21,7 +21,7 @@ properties:
   root_penetration:
     description: |
       The distance the weld metal extends into the root joint
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   groove_weld_size:
     description: |

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weld_details-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/design/weld_details-1.0.0.yaml
@@ -20,7 +20,7 @@ properties:
   weld_sizes:
     description: |
       Linear dimensions of cross sectional weld features. Sizes are of design and actual features. TODO CLASS
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   number_of_passes:
     description: |

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
@@ -34,6 +34,7 @@ properties:
     description: |
       Percentage by weight this gas occupies of the total gas mixture.
     tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+    wx_unit: "percent"
 
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/gas_component-1.0.0.yaml
@@ -33,7 +33,7 @@ properties:
   gas_percentage:
     description: |
       Percentage by weight this gas occupies of the total gas mixture.
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-1.0.0.yaml
@@ -41,7 +41,7 @@ properties:
   torch_shielding_gas_flowrate:
     description: |
       Flow rate of shielding gas required or specified.
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   use_backing_gas:
     description: |
@@ -56,7 +56,7 @@ properties:
   backing_gas_flowrate:
     description: |
       Flowrate of backing gas.
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   use_trailing_gas:
     description: |
@@ -71,7 +71,7 @@ properties:
   trailing_shielding_gas_flowrate:
     description: |
       Flowrate of trailing gas during welding.
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/data_array-1.0.0.yaml
@@ -21,11 +21,11 @@ properties:
       An array of variables that represent coordinates.
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
   data:
     description: |
       The actual data.
-    $ref: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
 
 required: [attributes, coordinates, data]
 propertyOrder: [attributes, coordinates, data]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/dataset-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/dataset-1.0.0.yaml
@@ -21,19 +21,19 @@ properties:
       An array of dimensions.
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/core/dimension-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/core/dimension-1.0.0"
   coordinates:
     description: |
       An array of variables that represent coordinates.
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
   variables:
     description: |
       An array of variables.
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
 
 required: [dimensions, coordinates, variables]
 propertyOrder: [attributes, dimensions, coordinates, variables]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/file-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/file-1.0.0.yaml
@@ -57,7 +57,7 @@ properties:
   content:
     description: |
       The content of the file. It is stored in the binary block of the file.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
   content_hash:
     description: |
       Hash data for the files content.

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-1.0.0.yaml
@@ -34,7 +34,7 @@ properties:
   coordinates:
     description: |
       The coordinates of the data points.
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     properties:
       datatype:
         type: string
@@ -48,7 +48,7 @@ properties:
   triangles:
     description: |
       An array of index triplets that specify which points form a triangle
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     properties:
       datatype:
         type: string

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_system_hierarchy-1.0.0.yaml
@@ -95,7 +95,7 @@ properties:
       towards their parent system.
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/core/transformations/coordinate_transformation-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/core/transformations/coordinate_transformation-1.0.0"
 
 propertyOrder: [name, root_system_name, reference_time, subsystems, subsystem_data,  coordinate_systems]
 required: [name, root_system_name, coordinate_systems]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_transformation-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/coordinate_transformation-1.0.0.yaml
@@ -48,7 +48,7 @@ properties:
   transformation:
     description: |
       Data that describes the orientation and position of the coordinate system towards its parent system.
-    $ref: "tag:weldx.bam.de:weldx/core/transformations/local_coordinate_system-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/core/transformations/local_coordinate_system-1.0.0"
 
 propertyOrder: [name, reference_system, transformation]
 required: [name, reference_system, transformation]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-1.0.0.yaml
@@ -101,15 +101,15 @@ properties:
   time:
     description: |
       A list of timestamps
-    tag: tag:weldx.bam.de:weldx/time/timedeltaindex-1.0.0
+    tag: "tag:weldx.bam.de:weldx/time/timedeltaindex-1.0.0"
   coordinates:
     description: |
       An ndarray containing the coordinates.
-    tag: tag:weldx.bam.de:weldx/core/variable-1.0.0
+    tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
   orientations:
     description: |
       An ndarray containing the orientations.
-    tag: tag:weldx.bam.de:weldx/core/variable-1.0.0
+    tag: "tag:weldx.bam.de:weldx/core/variable-1.0.0"
 
 wx_shape:
   (coordinates):

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/rotation-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/transformations/rotation-1.0.0.yaml
@@ -56,6 +56,7 @@ oneOf:
     properties:
       quaternions:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        wx_shape: [...,4]
     required: [quaternions]
     flowStyle: block
     additionalProperties: false
@@ -66,6 +67,7 @@ oneOf:
     properties:
       matrix:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        wx_shape: [...,3,3]
     required: [matrix]
     flowStyle: block
     additionalProperties: false
@@ -76,6 +78,7 @@ oneOf:
     properties:
       rotvec:
         tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+        wx_shape: [...,3]
     required: [rotvec]
     flowStyle: block
     additionalProperties: false

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
@@ -27,7 +27,7 @@ properties:
   data:
     description: |
       An n-dimensional array that contains the data.
-    $ref: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
   unit:
     description: |
       Optional field describing the unit of the data as valid string representation.

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/debug/test_shape_validator-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/debug/test_shape_validator-1.0.0.yaml
@@ -9,19 +9,19 @@ title: |
 type: object
 properties:
   prop1:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     wx_shape: [1,2,(3),(4)]
 
   prop2:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     wx_shape: [~,2,1]
 
   prop3:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     wx_shape: [2,4,6,8,...]
 
   prop4:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     wx_shape: [~,3,5,7,9]
 
   prop5:
@@ -40,10 +40,10 @@ properties:
     type: object
     properties:
       p1:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
         wx_shape: [10,8,6,4,2]
       p2:
-        tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
         wx_shape: [9,7,5,3,1]
 
   time_prop:
@@ -52,7 +52,7 @@ properties:
       - tag: "tag:weldx.bam.de:weldx/time/datetimeindex-1.0.0"
 
   optional_prop:
-    tag: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
     wx_shape: [1,2,(3),(4)]
 
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/debug/test_unit_validator-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/debug/test_unit_validator-1.0.0.yaml
@@ -11,21 +11,21 @@ properties:
   length_prop:
     description: |
       a simple length quantity with unit validator
-    tag: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
     wx_unit: "m"
 
   velocity_prop:
     description: |
       a simple velocity quantity
     allOf:
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
       - type: object
         wx_unit: "m/s"
 
   current_prop:
     description: |
       a current quantity of shape [2,2]
-    $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+    tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   nested_prop:
     description: |
@@ -34,10 +34,10 @@ properties:
     properties:
       q1:
         description: a nested length of shape [3,3]
-        $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
       q2:
         description: a volume
-        $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+        tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
     wx_unit:
       q1: "m"
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/equipment/generic_equipment-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/equipment/generic_equipment-1.0.0.yaml
@@ -41,11 +41,11 @@ properties:
   sources:
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/measurement/source-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/measurement/source-1.0.0"
   data_transformations:
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/measurement/data_transformation-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/measurement/data_transformation-1.0.0"
 
 propertyOrder: [name, sources, data_transformations]
 required: [name]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data-1.0.0.yaml
@@ -14,7 +14,7 @@ properties:
   name:
     type: string
   data:
-    $ref: "tag:weldx.bam.de:weldx/core/data_array-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/core/data_array-1.0.0"
 
 propertyOrder: [name, data]
 required: [data]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data_transformation-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/data_transformation-1.0.0.yaml
@@ -35,13 +35,13 @@ properties:
   name:
     type: string
   input_signal:
-    $ref: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
   output_signal:
-    $ref: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
   error:
-    $ref: "tag:weldx.bam.de:weldx/measurement/error-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/error-1.0.0"
   func:
-    $ref: "tag:weldx.bam.de:weldx/core/mathematical_expression-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/core/mathematical_expression-1.0.0"
 
 required: [name, input_signal, output_signal]
 propertyOrder: [name, input_signal, output_signal, error, func]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/error-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/error-1.0.0.yaml
@@ -23,7 +23,7 @@ properties:
       A simple numerical representation of the error.
     oneOf:
       - type: number
-      - $ref: tag:stsci.edu:asdf/unit/quantity-1.1.0
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 required: [deviation]
 flowStyle: block
 ...

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement-1.0.0.yaml
@@ -13,9 +13,9 @@ properties:
   data:
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/measurement/data-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/measurement/data-1.0.0"
   measurement_chain:
-    $ref: "tag:weldx.bam.de:weldx/measurement/measurement_chain-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/measurement_chain-1.0.0"
 
 
 propertyOrder: [name, data, measurement_chain]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement_chain-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/measurement_chain-1.0.0.yaml
@@ -11,11 +11,11 @@ properties:
   name:
     type: string
   data_source:
-    $ref: "tag:weldx.bam.de:weldx/measurement/source-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/source-1.0.0"
   data_processors:
     type: array
     items:
-      $ref: "tag:weldx.bam.de:weldx/measurement/data_transformation-1.0.0"
+      tag: "tag:weldx.bam.de:weldx/measurement/data_transformation-1.0.0"
 
 
 propertyOrder: [name, data_source, data_processors]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/signal-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/signal-1.0.0.yaml
@@ -28,7 +28,7 @@ properties:
   unit:
     type: string
   data:
-    $ref: "tag:weldx.bam.de:weldx/measurement/data-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/data-1.0.0"
 
 
 propertyOrder: [signal_type, unit, data]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/source-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/measurement/source-1.0.0.yaml
@@ -24,9 +24,9 @@ properties:
   name:
     type: string
   output_signal:
-    $ref: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/signal-1.0.0"
   error:
-    $ref: "tag:weldx.bam.de:weldx/measurement/error-1.0.0"
+    tag: "tag:weldx.bam.de:weldx/measurement/error-1.0.0"
 
 required: [name, output_signal]
 propertyOrder: [name, output_signal, error]

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/datetimeindex-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/datetimeindex-1.0.0.yaml
@@ -22,7 +22,7 @@ definitions:
   values:
     description: |
       Integer representation of a pandas DatetimeIndex in nanoseconds precision.
-    $ref: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
 
   start:
     description: |

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedeltaindex-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/time/timedeltaindex-1.0.0.yaml
@@ -34,7 +34,7 @@ definitions:
   values:
     description: |
       Integer representation of a pandas TimedeltaIndex in nanoseconds precision.
-    $ref: tag:stsci.edu:asdf/core/ndarray-1.0.0
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
 
   start:
     description: |


### PR DESCRIPTION
## Changes
I replaced some old `$ref` uses in schemas with `tag`, it should be more consistent now
if we're lucky this could even speed up some things

also add `wx_unit` to gas_component schema

## Related Issues

Closes #302, #296, #207

## Checks

- [x] ~updated CHANGELOG.md~
- [ ] ~updated tests~
- [ ] ~updated doc/~
- [ ] ~update example/tutorial notebooks~
