### PR TITLE
enforce agg backend during testing (windows) 

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,7 +41,9 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
-        run: pip install -e .[test]
+        run: |
+          pip install wheel
+          pip install -e .[test]
 
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')
@@ -49,6 +51,7 @@ jobs:
             if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
             echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
             python -c "import matplotlib as m; print(m.matplotlib_fname())"
+            python -c "import matplotlib as m; print(m.rc_params()['backend'])"
         shell: cmd
 
       - name: run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
             if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
             echo "backend: Agg" > %userprofile%\.matplotlib\matplotlibrc
+            python -c "import matplotlib as m; print(m.matplotlib_fname())"
         shell: cmd
 
       - name: run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         run: |
             if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
-            echo "backend: Agg" > %userprofile%\.matplotlib\matplotlibrc
+            echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
             python -c "import matplotlib as m; print(m.matplotlib_fname())"
         shell: cmd
 


### PR DESCRIPTION
## Changes

As the TK backend of matplotlib sometimes shows strange behavior on Windows, we want to use a different backend (Agg).

The exception thrown by the faulty tk initialization looks like this (for the archives);
```
     fig, ax = plt.subplots()
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\_api\deprecation.py:471: in wrapper
    return func(*args, **kwargs)
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\pyplot.py:1410: in subplots
    fig = figure(**fig_kw)
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\pyplot.py:768: in figure
    manager = new_figure_manager(
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\pyplot.py:316: in new_figure_manager
    return _backend_mod.new_figure_manager(*args, **kwargs)
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\backend_bases.py:3545: in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\site-packages\matplotlib\backends\_backend_tk.py:870: in new_figure_manager_given_figure
    window = tk.Tk(className="matplotlib")
c:\hostedtoolcache\windows\python\3.9.2\x64\lib\tkinter\__init__.py:2270: in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E   _tkinter.TclError: Can't find a usable init.tcl in the following directories: 
E       {c:\hostedtoolcache\windows\python\3.9.2\x64\tcl\tcl8.6}
E   
E   c:/hostedtoolcache/windows/python/3.9.2/x64/tcl/tcl8.6/init.tcl: couldn't read file "c:/hostedtoolcache/windows/python/3.9.2/x64/tcl/tcl8.6/init.tcl": No error
E   couldn't read file "c:/hostedtoolcache/windows/python/3.9.2/x64/tcl/tcl8.6/init.tcl": No error
E       while executing
E   "source c:/hostedtoolcache/windows/python/3.9.2/x64/tcl/tcl8.6/init.tcl"
E       ("uplevel" body line 1)
E       invoked from within
E   "uplevel #0 [list source $tclfile]"
E   
E   
E   This probably means that Tcl wasn't installed properly.
```

## Related Issues

Closes #321
