### PR TITLE
[rtd] fix install of packages (allow pinning)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,8 +24,4 @@ sphinx:
 #  image: testing
 conda:
   environment: doc/rtd_environment.yml
-python:
-   version: 3.8
-   install:
-      - method: pip
-        path: .
+

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
+    - -e ../

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - ipywidgets
   # documentation
   - sphinx=3
+  - jinja2=2
   - recommonmark
   - sphinxcontrib-napoleon
   - nbsphinx

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - ipykernel
   - ipywidgets
   # documentation
-  - sphinx=3
+  - sphinx
   - jinja2=2
   - recommonmark
   - sphinxcontrib-napoleon

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -7,11 +7,10 @@ dependencies:
   - ipykernel
   - ipywidgets
   # documentation
-  - sphinx
-  - jinja2=2
+  - sphinx=3
   - recommonmark
   - sphinxcontrib-napoleon
-  - nbsphinx>=0.8.5
+  - nbsphinx
   - sphinx-copybutton
   - pydata-sphinx-theme
   - numpydoc>=0.5


### PR DESCRIPTION
## Changes

On readthedocs we first create a conda environment containing the dependencies to build the documentation (sphinx etc),
then we install weldx via pip. The settings of the pip invocation are set to upgrade all previously installed packages, which
prevents pinning package versions. This ultimately leads to version incompatibilities (e.g. nbpshinx needs jinja2 < 3.0, but the conda installed version 2.11 gets upgraded to 3 again in the pip install call).

To prevent this, we do not install weldx via RTD directly, but via the pip section in doc/rtd_environment.yml   
