### PR TITLE
add dataclass_nested_eq decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - add `util.compare_nested_eq` decorator for dataclasses with array-like
   fields [[#378]](https://github.com/BAMWelDX/weldx/pull/378)
 
-
 ### changes
 
 - `WXRotation.from_euler()` now accepts a `pint.Quantity` as input. [[#318]](https://github.com/BAMWelDX/weldx/pull/318)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
   structures. [[#328]](https://github.com/BAMWelDX/weldx/pull/328)
 - added `WeldxFile` wrapper to handle asdf files with history and schemas more
   easily. [[#341]](https://github.com/BAMWelDX/weldx/pull/341).
-- added `WeldxFile` wrapper to handle asdf files with
-  history and schemas more easily. [[#341]](https://github.com/BAMWelDX/weldx/pull/341).
+- added `WeldxFile` wrapper to handle asdf files with history and schemas more
+  easily. [[#341]](https://github.com/BAMWelDX/weldx/pull/341).
 - add `"step"` as additional method to `util.xr_interp_like` [[#363]](https://github.com/BAMWelDX/weldx/pull/363)
-
+- add `util.compare_nested_eq` decorator for dataclasses with array-like
+  fields [[#378]](https://github.com/BAMWelDX/weldx/pull/378)
 
 ### changes
 
@@ -21,15 +22,14 @@
 - `get_yaml_header` received a new option parse, which optionally returns the parsed YAML header
   as `asdf.tagged.TaggedDict`. [[#338]](https://github.com/BAMWelDX/weldx/pull/338)
 - refactor `asdf_json_repr` into `view_tree` [[#339]](https://github.com/BAMWelDX/weldx/pull/339)
-- The `MeasurementChain` is now internally based on a `networkx.DiGraph`. New functions are also added to the class to 
+- The `MeasurementChain` is now internally based on a `networkx.DiGraph`. New functions are also added to the class to
   simplify its usage. [[#326]](https://github.com/BAMWelDX/weldx/pull/326)
   The following additional changes were applied during the update of the `MeasurementChain`:
-   - renamed `DataTransformation` class to `SignalTransformation`
-   - renamed `Source` to `SignalSource`
-   - Added additional functionality to `Signal`, `SignalTransformation` and `GenericEquipment`
-   - Removed `Data` class
-   - Updated asdf schemas of all modified classes and the ones that contained references to those classes
-   
+    - renamed `DataTransformation` class to `SignalTransformation`
+    - renamed `Source` to `SignalSource`
+    - Added additional functionality to `Signal`, `SignalTransformation` and `GenericEquipment`
+    - Removed `Data` class
+    - Updated asdf schemas of all modified classes and the ones that contained references to those classes
 
 ### documentation
 

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2294,6 +2294,7 @@ class Geometry:
 # SpatialData --------------------------------------------------------------------------
 
 
+@ut.dataclass_nested_eq
 @dataclass
 class SpatialData:
     """Represent 3D point cloud data with optional triangulation.

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -128,6 +128,48 @@ def ureg_check_class(*args):
     return inner_decorator
 
 
+def dataclass_nested_eq(original_class):
+    """Set class :code:`__eq__` using `util.compare_nested` on :code:`__dict__`.
+
+    Useful for implementing :code:`__eq__` on classes
+    created with :code:`@dataclass` decorator.
+
+    Parameters
+    ----------
+    original_class:
+        original class to decorate
+
+    Returns
+    -------
+    type
+        The class with overridden :code:`__eq__` function.
+
+    Examples
+    --------
+    A simple dataclass could look like this::
+
+        @dataclass_nested_eq
+        @dataclass
+        class A:
+            a: np.ndarray
+
+        a = A(np.arange(3))
+        b = A(np.arange(3))
+        assert a==b
+
+    """
+
+    def new_eq(self, other):
+        if not isinstance(other, type(self)):
+            return False
+
+        return compare_nested(self.__dict__, other.__dict__)
+
+    # set new eq function
+    original_class.__eq__ = new_eq  # Set the class' __eq__ to the new one
+    return original_class
+
+
 def _clean_notebook(file: Union[str, Path]):  # pragma: no cover
     """Clean ID metadata, output and execution count from jupyter notebook cells.
 

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -129,7 +129,7 @@ def ureg_check_class(*args):
 
 
 def dataclass_nested_eq(original_class):
-    """Set class :code:`__eq__` using `util.compare_nested` on :code:`__dict__`.
+    """Set class :code:`__eq__` using :code:`util.compare_nested` on :code:`__dict__`.
 
     Useful for implementing :code:`__eq__` on classes
     created with :code:`@dataclass` decorator.


### PR DESCRIPTION
## Changes
This adds the `util.dataclass_nested_eq` decorator to simplify defining `__eq__` on datacalsses that have array-like fileds such as `np.ndarray`, `xarray.DataArray` etc.

## Related Issues


## Checks

- [x] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
