### PR TITLE
Fix warnings from tests

### DIFF
--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -99,7 +99,7 @@ class VariableTypeASDF(WeldxType):
         dtype = node.data.dtype.str
         data = cls.convert_time_dtypes(data=data)
         if not data.shape:  # scalar
-            data = np.asscalar(data)
+            data = data.item()
         tree = {
             "name": node.name,
             "dimensions": node.dimensions,

--- a/weldx/tests/asdf_tests/test_asdf_aws_schema.py
+++ b/weldx/tests/asdf_tests/test_asdf_aws_schema.py
@@ -19,7 +19,7 @@ from weldx.asdf.tags.weldx.aws.process.shielding_gas_for_procedure import (
     ShieldingGasForProcedure,
 )
 from weldx.asdf.tags.weldx.aws.process.shielding_gas_type import ShieldingGasType
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.constants import WELDX_QUANTITY as Q_
 
 # iso groove -----------------------------------------------------------------
@@ -100,5 +100,5 @@ def test_aws_example():
 
     tree = dict(process=process, weldment=weldment, base_metal=base_metal)
 
-    data = _write_read_buffer(tree)
+    data = write_read_buffer(tree)
     assert isinstance(data, dict)

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -14,7 +14,7 @@ from scipy.spatial.transform import Rotation
 
 import weldx.transformations as tf
 from weldx.asdf.tags.weldx.core.file import ExternalFile
-from weldx.asdf.util import _write_buffer, write_read_buffer
+from weldx.asdf.util import write_buffer, write_read_buffer
 from weldx.constants import WELDX_QUANTITY as Q_
 from weldx.core import MathematicalExpression as ME  # nopep8
 from weldx.core import TimeSeries
@@ -251,7 +251,7 @@ def test_local_coordinate_system_shape_violation():
     )
 
     with pytest.raises(ValidationError):
-        _write_buffer({"lcs": lcs})
+        write_buffer({"lcs": lcs})
 
     # orientations have wrong shape -----------------------
     orientation = xr.DataArray(
@@ -269,7 +269,7 @@ def test_local_coordinate_system_shape_violation():
     )
 
     with pytest.raises(ValidationError):
-        _write_buffer({"lcs": lcs})
+        write_buffer({"lcs": lcs})
 
 
 # weldx.transformations.CoordinateSystemManager ----------------------------------------

--- a/weldx/tests/asdf_tests/test_asdf_gmaw_process.py
+++ b/weldx/tests/asdf_tests/test_asdf_gmaw_process.py
@@ -3,7 +3,7 @@
 import pytest
 
 from weldx import Q_
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.core import TimeSeries
 from weldx.welding.processes import GmawProcess
 
@@ -65,5 +65,5 @@ from weldx.welding.processes import GmawProcess
     ],
 )
 def test_gmaw_process(inputs):
-    data = _write_read_buffer({"root": inputs})
+    data = write_read_buffer({"root": inputs})
     assert data["root"] == inputs

--- a/weldx/tests/asdf_tests/test_asdf_groove.py
+++ b/weldx/tests/asdf_tests/test_asdf_groove.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import pytest
 from decorator import contextmanager
 
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.constants import WELDX_QUANTITY as Q_
 from weldx.geometry import Profile
 from weldx.welding.groove.iso_9692_1 import (
@@ -34,7 +34,7 @@ def test_asdf_groove(groove: IsoBaseGroove, expected_dtype):
     k = "groove"
     tree = {k: groove}
 
-    data = _write_read_buffer(tree)
+    data = write_read_buffer(tree)
     assert isinstance(
         data[k], expected_dtype
     ), f"Did not match expected type {expected_dtype} on item {data[k]}"

--- a/weldx/tests/asdf_tests/test_asdf_measurement.py
+++ b/weldx/tests/asdf_tests/test_asdf_measurement.py
@@ -1,7 +1,7 @@
 import pytest
 
 from weldx import Q_
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.core import MathematicalExpression
 from weldx.measurement import (
     Error,
@@ -89,7 +89,7 @@ def measurement_chain_with_equipment() -> MeasurementChain:
 def test_measurement_chain(copy_arrays, lazy_load, measurement_chain):
     """Test the asdf serialization of the measurement chain."""
     tree = {"m_chain": measurement_chain}
-    data = _write_read_buffer(
+    data = write_read_buffer(
         tree, open_kwargs={"copy_arrays": copy_arrays, "lazy_load": lazy_load}
     )
     mc_file = data["m_chain"]

--- a/weldx/tests/asdf_tests/test_asdf_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_types.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from weldx.asdf.types import META_ATTR, USER_ATTR
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.measurement import Error
 
 
@@ -16,7 +16,7 @@ def test_meta_attr():
 
     tree = {"Error": e}
 
-    data = _write_read_buffer(tree)
+    data = write_read_buffer(tree)
 
     e2 = data["Error"]
 

--- a/weldx/tests/asdf_tests/test_asdf_validators.py
+++ b/weldx/tests/asdf_tests/test_asdf_validators.py
@@ -9,7 +9,7 @@ from weldx.asdf.extension import WxSyntaxError
 from weldx.asdf.tags.weldx.debug.test_property_tag import PropertyTagTestClass
 from weldx.asdf.tags.weldx.debug.test_shape_validator import ShapeValidatorTestClass
 from weldx.asdf.tags.weldx.debug.test_unit_validator import UnitValidatorTestClass
-from weldx.asdf.util import _write_read_buffer
+from weldx.asdf.util import write_read_buffer
 from weldx.asdf.validators import _compare_tag_version, _custom_shape_validator
 from weldx.util import compare_nested
 
@@ -56,7 +56,7 @@ def test_wx_tag_syntax_exceptions(instance_tag, tagname, err):
 )
 def test_property_tag_validator(test_input):
     """Test custom ASDF shape validators."""
-    _write_read_buffer({"root_node": test_input})
+    write_read_buffer({"root_node": test_input})
 
 
 @pytest.mark.parametrize(
@@ -69,7 +69,7 @@ def test_property_tag_validator(test_input):
 def test_property_tag_validator_exceptions(test_input, err):
     """Test custom ASDF shape validators."""
     with pytest.raises(err):
-        _write_read_buffer({"root_node": test_input})
+        write_read_buffer({"root_node": test_input})
 
 
 def _val(list_test, list_expected):
@@ -182,7 +182,7 @@ def test_shape_validation_error_exception(shape, exp, err):
     ],
 )
 def test_shape_validator(test_input):
-    result = _write_read_buffer(
+    result = write_read_buffer(
         {"root": test_input},
     )["root"]
     assert compare_nested(test_input.__dict__, result.__dict__)
@@ -217,7 +217,7 @@ def test_shape_validator(test_input):
 )
 def test_shape_validator_exceptions(test_input):
     with pytest.raises(ValidationError):
-        _write_read_buffer({"root": test_input})
+        write_read_buffer({"root": test_input})
 
 
 @pytest.mark.parametrize(
@@ -283,7 +283,7 @@ def test_shape_validator_exceptions(test_input):
     ],
 )
 def test_unit_validator(test):
-    data = _write_read_buffer({"root_node": test})
+    data = write_read_buffer({"root_node": test})
     test_read = data["root_node"]
     assert isinstance(data, dict)
     assert test_read.length_prop == test.length_prop

--- a/weldx/tests/test_visualization.py
+++ b/weldx/tests/test_visualization.py
@@ -28,8 +28,7 @@ def test_plot_coordinate_system():
         orientation=orientation_tdp, coordinates=coordinates_tdp, time=time
     )
 
-    fig = plt.figure()
-    ax = fig.gca(projection="3d")
+    fig, ax = plt.subplots(subplot_kw=dict(projection="3d"))
 
     vs.draw_coordinate_system_matplotlib(lcs_constant, ax, "g")
     vs.draw_coordinate_system_matplotlib(lcs_tdp, ax, "r", "2016-01-10")
@@ -47,6 +46,5 @@ def test_plot_coordinate_system():
 
 def test_axes_equal():
     """Test executing all possible code paths."""
-    fig = plt.figure()
-    ax = fig.gca(projection="3d")
+    fig, ax = plt.subplots(subplot_kw=dict(projection="3d"))
     vs.axes_equal(ax)

--- a/weldx/tests/test_visualization.py
+++ b/weldx/tests/test_visualization.py
@@ -28,7 +28,7 @@ def test_plot_coordinate_system():
         orientation=orientation_tdp, coordinates=coordinates_tdp, time=time
     )
 
-    fig, ax = plt.subplots(subplot_kw=dict(projection="3d"))
+    _, ax = plt.subplots(subplot_kw=dict(projection="3d"))
 
     vs.draw_coordinate_system_matplotlib(lcs_constant, ax, "g")
     vs.draw_coordinate_system_matplotlib(lcs_tdp, ax, "r", "2016-01-10")
@@ -46,5 +46,5 @@ def test_plot_coordinate_system():
 
 def test_axes_equal():
     """Test executing all possible code paths."""
-    fig, ax = plt.subplots(subplot_kw=dict(projection="3d"))
+    _, ax = plt.subplots(subplot_kw=dict(projection="3d"))
     vs.axes_equal(ax)

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -1278,12 +1278,18 @@ _eq_compare_nested_input_types = Union[
 ]
 
 
+def _array_equal(a, b):
+    if a.shape != b.shape:
+        return False
+    return np.all(a == b)
+
+
 class _Eq_compare_nested:
     """Compares nested data structures like lists, sets, tuples, arrays, etc."""
 
     # some types need special comparison handling.
     compare_funcs = {
-        (np.ndarray, NDArrayType, pint.Quantity, pd.Index): lambda x, y: np.all(x == y),
+        (np.ndarray, NDArrayType, pint.Quantity, pd.Index): _array_equal,
         (xr.DataArray, xr.Dataset): lambda x, y: x.identical(y),
     }
     # these types will be treated as equivalent.


### PR DESCRIPTION
## Changes

Removes most of the warnings while running the tests (lots of our own deprecation warnings). 

## Checks

- [ ] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
