### PR TITLE
[asdf/xarray.DataSet|DataArray] fix serialization of attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - replace references to base asdf tags with `-1.*` version wildcard [[#373]](https://github.com/BAMWelDX/weldx/pull/373)
 - update `single-pass-weldx.1.0.0.schema` to allow groove types by
   wildcard [[#373]](https://github.com/BAMWelDX/weldx/pull/373)
+- fix attributes serialization of DataSet children [[#384]](https://github.com/BAMWelDX/weldx/pull/384).  
 
 ### fixes
 

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -1,5 +1,6 @@
+import dataclasses
 from dataclasses import dataclass
-from typing import List
+from typing import List, Mapping, Hashable, Any
 
 import numpy as np
 import pint
@@ -35,6 +36,7 @@ class Variable:
     name: str
     dimensions: List
     data: np.ndarray
+    attrs: Mapping[Hashable, Any] = dataclasses.field(default_factory=dict)
 
 
 class VariableTypeASDF(WeldxType):
@@ -105,6 +107,7 @@ class VariableTypeASDF(WeldxType):
             "dimensions": node.dimensions,
             "dtype": dtype,
             "data": data,
+            "attrs": node.attrs,
         }
         if unit:
             tree["unit"] = unit
@@ -135,4 +138,4 @@ class VariableTypeASDF(WeldxType):
         if "unit" in tree:  # convert to pint.Quantity
             data = Q_(data, tree["unit"])
 
-        return Variable(tree["name"], tree["dimensions"], data)
+        return Variable(tree["name"], tree["dimensions"], data, tree["attrs"])

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -138,8 +138,6 @@ class VariableTypeASDF(WeldxType):
         if "unit" in tree:  # convert to pint.Quantity
             data = Q_(data, tree["unit"])
 
-        # FIXME: for some reason, "attrs" is not set in the tree
-        # (sometimes, e.g. coordinate transformation schema)
         attrs = tree.get("attrs", None)
 
         return Variable(tree["name"], tree["dimensions"], data, attrs)

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -138,4 +138,7 @@ class VariableTypeASDF(WeldxType):
         if "unit" in tree:  # convert to pint.Quantity
             data = Q_(data, tree["unit"])
 
-        return Variable(tree["name"], tree["dimensions"], data, tree["attrs"])
+        # FIXME: for some reason, "attrs" is not set in the tree (sometimes, e.g. coordinate transformation schema)
+        attrs = tree.get("attrs", None)
+
+        return Variable(tree["name"], tree["dimensions"], data, attrs)

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -138,7 +138,8 @@ class VariableTypeASDF(WeldxType):
         if "unit" in tree:  # convert to pint.Quantity
             data = Q_(data, tree["unit"])
 
-        # FIXME: for some reason, "attrs" is not set in the tree (sometimes, e.g. coordinate transformation schema)
+        # FIXME: for some reason, "attrs" is not set in the tree
+        # (sometimes, e.g. coordinate transformation schema)
         attrs = tree.get("attrs", None)
 
         return Variable(tree["name"], tree["dimensions"], data, attrs)

--- a/weldx/asdf/tags/weldx/core/data_array.py
+++ b/weldx/asdf/tags/weldx/core/data_array.py
@@ -34,11 +34,11 @@ class XarrayDataArrayASDF(WeldxType):
 
         """
         attributes = node.attrs
-        coordinates = []
-        data = ct.Variable("data", node.dims, node.data)
-
-        for name, coord_data in node.coords.items():
-            coordinates.append(ct.Variable(name, coord_data.dims, coord_data.data))
+        coordinates = [
+            ct.Variable(name, coord_data.dims, coord_data.data, attrs=coord_data.attrs)
+            for name, coord_data in node.coords.items()
+        ]
+        data = ct.Variable("data", node.dims, node.data, attrs={})
 
         tree = {
             "attributes": attributes,
@@ -69,12 +69,8 @@ class XarrayDataArrayASDF(WeldxType):
         """
         data = tree["data"].data
         dims = tree["data"].dimensions
-        coords = {}
-        for coordinate in tree["coordinates"]:
-            coords[coordinate.name] = (coordinate.dimensions, coordinate.data)
+        coords = {c.name: (c.dimensions, c.data, c.attrs) for c in tree["coordinates"]}
+        attrs = tree["attributes"]
 
-        obj = DataArray(data=data, coords=coords, dims=dims)
-
-        obj.attrs = tree["attributes"]
-
-        return obj
+        da = DataArray(data=data, coords=coords, dims=dims, attrs=attrs)
+        return da

--- a/weldx/asdf/tags/weldx/core/dataset.py
+++ b/weldx/asdf/tags/weldx/core/dataset.py
@@ -75,6 +75,4 @@ class XarrayDatasetASDF(WeldxType):
         data_vars = {v.name: (v.dimensions, v.data, v.attrs) for v in tree["variables"]}
         coords = {c.name: (c.dimensions, c.data, c.attrs) for c in tree["coordinates"]}
 
-        ds = Dataset(data_vars=data_vars, coords=coords, attrs=tree["attributes"])
-
-        return ds
+        return Dataset(data_vars=data_vars, coords=coords, attrs=tree["attributes"])

--- a/weldx/tests/asdf_tests/test_asdf_base_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_base_types.py
@@ -1,6 +1,7 @@
 """Tests asdf implementations of python base types."""
 import uuid
-
+import xarray as xr
+import numpy as np
 import pytest
 from asdf import ValidationError
 
@@ -16,3 +17,14 @@ def test_uuid():
 
     with pytest.raises(ValidationError):
         write_read_buffer({"id": uuid.uuid1()})
+
+
+# --------------------------------------------------------------------------------------
+# xarray.DataSet
+# --------------------------------------------------------------------------------------
+def test_dataset_children():
+    da = xr.DataArray(np.arange(10), name="arr1", attrs={"name": "sample data"})
+    ds = da.to_dataset()
+    ds2 = write_read_buffer({"ds": ds})["ds"]
+    assert ds.arr1.attrs == ds2.arr1.attrs
+    assert np.all(ds.arr1 == ds2.arr1)

--- a/weldx/tests/asdf_tests/test_asdf_base_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_base_types.py
@@ -20,11 +20,19 @@ def test_uuid():
 
 
 # --------------------------------------------------------------------------------------
-# xarray.DataSet
+# xarray
 # --------------------------------------------------------------------------------------
+def test_dataarray():
+    da = xr.DataArray(np.random.randn(2, 3), dims=("x", "y"), coords={"x": [10, 20]})
+    da.attrs["long_name"] = "random velocity"
+    # add metadata to coordinate
+    da.x.attrs["units"] = "x units"
+    da2 = write_read_buffer({"da": da})["da"]
+    assert da2.identical(da)
+
+
 def test_dataset_children():
     da = xr.DataArray(np.arange(10), name="arr1", attrs={"name": "sample data"})
     ds = da.to_dataset()
     ds2 = write_read_buffer({"ds": ds})["ds"]
-    assert ds.arr1.attrs == ds2.arr1.attrs
-    assert np.all(ds.arr1 == ds2.arr1)
+    assert ds2.identical(ds)


### PR DESCRIPTION
## Changes

The wrapping of `Variables` inside the `DataSet` serialization did not contain the `attrs` property. Additionally, the `coordinates`
of a `DataArray` can also enclose attributes, these were also not being serialized.

Refactored some for loops in favor of list comprehensions.

## Related Issues

Closes #349

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
