### PR TITLE
pandas v1.3 & pytest warnings

### DIFF
--- a/weldx/asdf/tags/weldx/aws/process/arc_welding_process.py
+++ b/weldx/asdf/tags/weldx/aws/process/arc_welding_process.py
@@ -59,8 +59,13 @@ class ArcWeldingProcess:
             )
 
 
+def _from_tree(tree):
+    return dict(name_or_abbreviation=tree["name"])
+
+
 ArcWeldingProcessType = dataclass_serialization_class(
     class_type=ArcWeldingProcess,
     class_name="aws/process/arc_welding_process",
     version="1.0.0",
+    from_tree_mod=_from_tree,
 )

--- a/weldx/tests/asdf_tests/test_asdf_aws_schema.py
+++ b/weldx/tests/asdf_tests/test_asdf_aws_schema.py
@@ -21,6 +21,7 @@ from weldx.asdf.tags.weldx.aws.process.shielding_gas_for_procedure import (
 from weldx.asdf.tags.weldx.aws.process.shielding_gas_type import ShieldingGasType
 from weldx.asdf.util import write_read_buffer
 from weldx.constants import WELDX_QUANTITY as Q_
+from weldx.util import compare_nested
 
 # iso groove -----------------------------------------------------------------
 from weldx.welding.groove.iso_9692_1 import get_groove
@@ -101,4 +102,6 @@ def test_aws_example():
     tree = dict(process=process, weldment=weldment, base_metal=base_metal)
 
     data = write_read_buffer(tree)
-    assert isinstance(data, dict)
+    data.pop("asdf_library", None)
+    data.pop("history", None)
+    assert compare_nested(data, tree)

--- a/weldx/tests/test_utility.py
+++ b/weldx/tests/test_utility.py
@@ -124,11 +124,11 @@ def test_vector_is_close():
     "arg, expected",
     [
         # timedeltas
-        (TDI([42]), TDI([42])),
+        (TDI([42], unit="ns"), TDI([42], unit="ns")),
         (pd.timedelta_range("0s", "20s", 10), pd.timedelta_range("0s", "20s", 10)),
-        (np.timedelta64(42), TDI([42])),
-        (np.array([-10, 0, 20]).astype(np.timedelta64), TDI([-10, 0, 20])),
-        (Q_(42, "ns"), TDI([42])),
+        (np.timedelta64(42), TDI([42], unit="ns")),
+        (np.array([-10, 0, 20]).astype("timedelta64[ns]"), TDI([-10, 0, 20], "ns")),
+        (Q_(42, "ns"), TDI([42], unit="ns")),
         ("10s", TDI(["10s"])),
         (["5ms", "10s", "2D"], TDI(["5 ms", "10s", "2D"])),
         # datetimes

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -707,20 +707,19 @@ class LocalCoordinateSystem:
     @property
     def is_unity_translation(self) -> bool:
         """Return true if the LCS has a zero translation/coordinates value."""
-        if self.coordinates.shape[-1] == 3 and np.allclose(
-            self.coordinates, np.zeros(3)
-        ):
-            return True
-        return False
+        coords = (
+            self.coordinates.data.magnitude
+            if isinstance(self.coordinates.data, pint.Quantity)
+            else self.coordinates.data
+        )
+        return coords.shape[-1] == 3 and np.allclose(coords, np.zeros(3))
 
     @property
     def is_unity_rotation(self) -> bool:
         """Return true if the LCS represents a unity rotation/orientations value."""
-        if self.orientation.shape[-2:] == (3, 3) and np.allclose(
-            self.orientation, np.eye(3)
-        ):
-            return True
-        return False
+        return self.orientation.shape[-2:] == (3, 3) and np.allclose(
+            self.orientation.values, np.eye(3)
+        )
 
     def as_euler(
         self, seq: str = "xyz", degrees: bool = False

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -1083,9 +1083,9 @@ def xr_interp_orientation_in_time(
 
         # interpolate rotations in the intersecting time range
         rotations_key = Rot.from_matrix(dsx.transpose(..., "c", "v").data)
-        times_key = times_ds.astype(np.int64)
+        times_key = times_ds.view(np.int64)
         rotations_interp = Slerp(times_key, rotations_key)(
-            times_intersect.astype(np.int64)
+            times_intersect.view(np.int64)
         )
         dsx_out = xr_3d_matrix(rotations_interp.as_matrix(), times_intersect)
     else:


### PR DESCRIPTION
## Changes
- handle pandas 1.3 deprecations (and one error)
- fix `ArcWeldingProcess` serialization (custom `from_tree`)
- fixes some warning related to unhandled pint downcasting in LCS code in popping up tests