### PR TITLE
Update variable schema with attrs field

### DIFF
--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/variable-1.0.0.yaml
@@ -34,6 +34,10 @@ properties:
     description: |
       Optional field describing the unit of the data as valid string representation.
     type: string
+  attrs:
+    description: |
+      Additional attributes metadata associated with the variable.
+    type: object
 
 required: [name, dimensions, dtype, data]
 propertyOrder: [name, dimensions, dtype, unit, data]

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -1,6 +1,6 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import List, Mapping, Hashable, Any
+from typing import Any, Hashable, List, Mapping
 
 import numpy as np
 import pint

--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -107,7 +107,7 @@ class VariableTypeASDF(WeldxType):
             "dimensions": node.dimensions,
             "dtype": dtype,
             "data": data,
-            "attrs": node.attrs,
+            "attrs": node.attrs if node.attrs else None,
         }
         if unit:
             tree["unit"] = unit

--- a/weldx/tests/asdf_tests/test_asdf_base_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_base_types.py
@@ -1,8 +1,9 @@
 """Tests asdf implementations of python base types."""
 import uuid
-import xarray as xr
+
 import numpy as np
 import pytest
+import xarray as xr
 from asdf import ValidationError
 
 from weldx.asdf.util import write_read_buffer


### PR DESCRIPTION
## Changes
- update schema to include `attrs` 
- `attrs` field no longer gets serialized when empty

## Related Issues
see #384 