### PR TITLE
Add output_signal property to MeasurementChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - adds a `dataclass_serialization_class` utility function that automatically generates the asdf serialization class for 
   python dataclasses. [[#380]](https://github.com/BAMWelDX/weldx/pull/380)
 - Added method to set the interpolation method to the `TimeSeries` [[#353]](https://github.com/BAMWelDX/weldx/pull/353)
+- Add `MeasurementChain.output_signal` property that returns the output signal of the `MeasurementChain`
+  [[#394]](https://github.com/BAMWelDX/weldx/pull/394)
+
 
 ### changes
 

--- a/weldx/measurement.py
+++ b/weldx/measurement.py
@@ -1053,6 +1053,11 @@ class MeasurementChain:
             self._graph.edges[edge]["transformation"].name for edge in self._graph.edges
         ]
 
+    @property
+    def output_signal(self) -> Signal:
+        """Get the output signal of the measurement chain."""
+        return self.signals[-1]
+
 
 @dataclass
 class Measurement:

--- a/weldx/tests/test_measurement.py
+++ b/weldx/tests/test_measurement.py
@@ -233,7 +233,7 @@ class TestMeasurementChain:
 
         mc.add_transformation(self._default_transformation(tf_kwargs))
 
-        signal = mc.get_signal("transformation")
+        signal = mc.output_signal
         assert signal.signal_type == exp_signal_type
         assert signal.unit == exp_signal_unit
 


### PR DESCRIPTION
## Changes

Adds a new property to the `MeasurementChain` that returns the output signal of the chain

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] update example/tutorial notebooks 
