### PR TITLE
Math expr param tag

### DIFF
--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -19,4 +19,4 @@ jobs:
           pip install -e .[test]
       - name: run pytest
         run: |
-          pytest --asdf-tests --ignore=weldx/tests/ --no-cov
+          pytest --asdf-tests --ignore=weldx/tests/ --no-cov weldx/asdf/schemas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,11 +66,18 @@
 - update `wx_shape` syntax in `local_coordinate_system-1.0.0` [[#366]](https://github.com/BAMWelDX/weldx/pull/366)
 - add custom `wx_shape` validation to `variable-1.0.0` [[#366]](https://github.com/BAMWelDX/weldx/pull/366)
 - remove outdated `TimeSeries` shape validation code [[#399]](https://github.com/BAMWelDX/weldx/pull/399)
+- use asdf tag validation pattern for `wx_property_tag` [[#410]](https://github.com/BAMWelDX/weldx/pull/410)
+- update `MathematicalExpression` schema [[#410]](https://github.com/BAMWelDX/weldx/pull/410)
 
 ### fixes
 
 - added check for symmetric key difference for mappings
   with `util.compare_nested` [[#377]](https://github.com/BAMWelDX/weldx/pull/377)
+
+### deprecations
+
+- deprecate `wx_tag` validator (use default asdf uri pattern
+  matching) [[#410]](https://github.com/BAMWelDX/weldx/pull/410)
 
 ## 0.3.3 (30.03.2021)
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
@@ -25,8 +25,13 @@ examples:
 type: object
 properties:
   expression:
+    description: |
+      A string representation of the mathematical expression.
+      The expression must conform to the sympy syntax.
     type: string
   parameters:
+    description: |
+      List of constant parameters that to be set in the mathematical expression.
     type: object
     wx_property_tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 

--- a/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
+++ b/weldx/asdf/schemas/weldx.bam.de/weldx/core/mathematical_expression-1.0.0.yaml
@@ -28,6 +28,7 @@ properties:
     type: string
   parameters:
     type: object
+    wx_property_tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
 
 required: [expression]
 propertyOrder: [expression, parameters]

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -5,12 +5,14 @@ import asdf
 from asdf import ValidationError
 from asdf.schema import _type_to_tag
 from asdf.tagged import TaggedDict
+from asdf.util import uri_match
 
 from weldx.asdf.extension import WxSyntaxError
 from weldx.asdf.tags.weldx.time.datetimeindex import DatetimeIndexType
 from weldx.asdf.tags.weldx.time.timedeltaindex import TimedeltaIndexType
 from weldx.constants import WELDX_QUANTITY as Q_
 from weldx.constants import WELDX_UNIT_REGISTRY as UREG
+from weldx.util import deprecated
 
 
 def _walk_validator(
@@ -558,6 +560,7 @@ def wx_shape_validator(
         )
 
 
+@deprecated("0.4.0", "0.5.0", " _compare_tag_version will be removed in 0.5.0")
 def _compare_tag_version(instance_tag: str, tagname: str):
     """Compare ASDF tag-strings with flexible version syntax.
 
@@ -598,6 +601,11 @@ def _compare_tag_version(instance_tag: str, tagname: str):
     return True
 
 
+@deprecated(
+    "0.4.0",
+    "0.5.0",
+    "wx_tag_validator will be removed in 0.5.0. Use asdf tag validation instead.",
+)
 def wx_tag_validator(validator, tagname, instance, schema):
     """Validate instance tag string with flexible version syntax.
 
@@ -631,7 +639,7 @@ def wx_tag_validator(validator, tagname, instance, schema):
         instance_tag = _type_to_tag(type(instance))
 
     if instance_tag is not None:
-        if not _compare_tag_version(instance_tag, tagname):
+        if not uri_match(tagname, instance_tag):
             yield ValidationError(
                 "mismatched tags, wanted '{0}', got '{1}'".format(tagname, instance_tag)
             )

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -601,11 +601,6 @@ def _compare_tag_version(instance_tag: str, tagname: str):
     return True
 
 
-@deprecated(
-    "0.4.0",
-    "0.5.0",
-    "wx_tag_validator will be removed in 0.5.0. Use asdf tag validation instead.",
-)
 def wx_tag_validator(validator, tagname, instance, schema):
     """Validate instance tag string with flexible version syntax.
 


### PR DESCRIPTION
## Changes
- update math expression schema
- use asdf default pattern matching for tag validation
- deprecate old pattern matching code

## Related Issues
Closes #273

## Checks

- [x] updated CHANGELOG.md
