### PR TITLE
[WeldxFile] resolve custom_schema within weldx package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
   places [[#402]](https://github.com/BAMWelDX/weldx/pull/402)
 - `LocalCoordinateSystem.__init__` now accepts a `TimeSeries` as input. All methods of the `CoordinateSystemManager`
   also support this new behavior [[#366]](https://github.com/BAMWelDX/weldx/pull/366)
+- During the creation of a `WeldxFile` the path of a passed custom schema is resolved automatically
+  [[#412]](https://github.com/BAMWelDX/weldx/pull/412).
+
 
 ### documentation
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -16,7 +16,7 @@ from asdf.util import get_file_type
 from jsonschema import ValidationError
 
 from weldx.asdf import WeldxAsdfExtension, WeldxExtension
-from weldx.asdf.util import get_yaml_header, view_tree
+from weldx.asdf.util import get_yaml_header, view_tree, get_schema_path
 from weldx.types import SupportsFileReadWrite, types_file_like, types_path_and_file_like
 
 __all__ = [
@@ -94,6 +94,14 @@ class WeldxFile(UserDict):
 
         self._asdffile_kwargs = asdffile_kwargs
         if custom_schema is not None:
+            _custom_schema_path = pathlib.Path(custom_schema)
+            if not _custom_schema_path.exists():
+                try:
+                    custom_schema = get_schema_path(custom_schema)
+                except ValueError:
+                    raise ValueError(
+                        f"provided custom_schema {custom_schema} " "does not exist."
+                    )
             asdffile_kwargs["custom_schema"] = custom_schema
 
         if mode not in ("r", "rw"):

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -63,7 +63,8 @@ class WeldxFile(UserDict):
         If True, the changes to file will be written upon closing this. This is only
         relevant, if the file has been opened in write mode.
     custom_schema :
-        a path-like object to a custom schema which validates the tree.
+        A path-like object to a custom schema which validates the tree. All schemas
+        provided by weldx can be given by name as well.
     software_history_entry :
         An optional dictionary which will be used to add history entries upon
         modification of the file. It has to provide the following keys:

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -321,7 +321,8 @@ class TestWeldXFile:
         with pytest.raises(ValueError):
             WeldxFile(custom_schema="no")
 
-    def test_custom_schema_real_file(self, tmpdir):
+    @staticmethod
+    def test_custom_schema_real_file(tmpdir):
         """Passing real paths."""
         assert not pathlib.Path("single_pass_weld-1.0.0.schema").exists()
         shutil.copy(get_schema_path("single_pass_weld-1.0.0.schema"), ".")

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -309,6 +309,7 @@ class TestWeldXFile:
 
     @staticmethod
     def test_custom_schema_resolve_path():
+        """Schema paths should be resolved internally."""
         schema = "single_pass_weld-1.0.0.schema"
         with pytest.raises(ValidationError) as e:
             WeldxFile(custom_schema=schema)
@@ -316,10 +317,12 @@ class TestWeldXFile:
 
     @staticmethod
     def test_custom_schema_not_existent():
+        """Non existent schema should raise."""
         with pytest.raises(ValueError):
             WeldxFile(custom_schema="no")
 
     def test_custom_schema_real_file(self, tmpdir):
+        """Passing real paths."""
         assert not pathlib.Path("single_pass_weld-1.0.0.schema").exists()
         shutil.copy(get_schema_path("single_pass_weld-1.0.0.schema"), ".")
         with pytest.raises(ValueError):

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -1,11 +1,13 @@
 """Tests for the WeldxFile class."""
 import io
 import pathlib
+import shutil
 import tempfile
 from io import BytesIO
 
 import asdf
 import pytest
+from jsonschema import ValidationError
 
 from weldx import WeldxFile
 from weldx.asdf.cli.welding_schema import single_pass_weld_example
@@ -304,6 +306,24 @@ class TestWeldXFile:
             kwargs = {"asdffile_kwargs": {"custom_schema": schema}}
         w = WeldxFile(buff, **kwargs)
         assert w.custom_schema == schema
+
+    @staticmethod
+    def test_custom_schema_resolve_path():
+        schema = "single_pass_weld-1.0.0.schema"
+        with pytest.raises(ValidationError) as e:
+            WeldxFile(custom_schema=schema)
+        assert "required property" in e.value.message
+
+    @staticmethod
+    def test_custom_schema_not_existent():
+        with pytest.raises(ValueError):
+            WeldxFile(custom_schema="no")
+
+    def test_custom_schema_real_file(self, tmpdir):
+        assert not pathlib.Path("single_pass_weld-1.0.0.schema").exists()
+        shutil.copy(get_schema_path("single_pass_weld-1.0.0.schema"), ".")
+        with pytest.raises(ValueError):
+            WeldxFile(custom_schema="no")
 
     @staticmethod
     def test_show_header_file_pos_unchanged():


### PR DESCRIPTION
## Changes

First WeldxFile tries to resolve custom_schema to a file, then use get_schema_path internally
to resolve the path.

## Related Issues

Closes #398

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
