### PR TITLE
swap recommonmark to myst parser

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,7 +85,7 @@ pygments_style = "sphinx"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "recommonmark",
+    "myst_parser",
     "sphinxcontrib.napoleon",
     "nbsphinx",
     "sphinx.ext.autodoc",

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -9,7 +9,7 @@ dependencies:
   # documentation
   - sphinx
   - jinja2=2
-  - recommonmark
+  - myst-parser
   - sphinxcontrib-napoleon
   - nbsphinx
   - sphinx-copybutton


### PR DESCRIPTION
## Changes
seems like recommonmark is going inactive ion favor of myst: https://recommonmark.readthedocs.io/en/latest/


## Related Issues

Closes # (add issue numbers)

## Checks

- [ ] updated CHANGELOG.md
- [ ] updated tests
- [x] updated doc/
- [ ] update example/tutorial notebooks 
