### PR TITLE
Deprecate util.lcs_coords_from_ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### deprecations
 
+- `lcs_coords_from_ts` will be removed in version 0.5.0 [[#426]](https://github.com/BAMWelDX/weldx/pull/426)
+
 ### dependencies
 
 ## 0.4.0 (13.07.2021)

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -263,6 +263,12 @@ def sine(
     return TimeSeries(expr)
 
 
+@deprecated(
+    "0.4.1",
+    "0.5.0",
+    "The 'LocalCoordinateSystem' now supports 'TimeSeries' as coordinates rendering "
+    "this function obsolete.",
+)
 def lcs_coords_from_ts(
     ts: TimeSeries, time: Union[pd.DatetimeIndex, pint.Quantity]
 ) -> xr.DataArray:


### PR DESCRIPTION
## Changes

Deprecates `util.lcs_coords_from_ts`

## Related Issues

Closes #408

## Checks

- [x] updated CHANGELOG.md
- [x] ~~updated tests~~
- [x] ~~updated doc/~~
- [x] ~~update example/tutorial notebooks~~
