### PR TITLE
[WeldxFile] fix show header in non interactive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### fixes
 
+- `WeldxFile.show_asdf_header` prints output on console, before it only returned the header
+  as parsed dict and string representation [[#]]().
+
 ### documentation
 
 ### ASDF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### fixes
 
 - `WeldxFile.show_asdf_header` prints output on console, before it only returned the header
-  as parsed dict and string representation [[#]]().
+  as parsed dict and string representation [[#428]](https://github.com/BAMWelDX/weldx/pull/428).
 
 ### documentation
 

--- a/doc/changelog_link.rst
+++ b/doc/changelog_link.rst
@@ -1,2 +1,2 @@
-
+.. py:currentmodule:: weldx
 .. mdinclude:: ../CHANGELOG.md

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -503,15 +503,15 @@ class WeldxFile(UserDict):
         --- !core/asdf-1.1.0
         asdf_library: !core/software-1.0.0 {author: The ASDF Developers,
           homepage: 'http://github.com/asdf-format/asdf',
-          name: asdf, version: ...}
+          name: asdf, version: ... }
         history:
           extensions:
           - !core/extension_metadata-1.0.0
             extension_class: asdf.extension.BuiltinExtension
-            software: !core/software-1.0.0 {name: asdf, version: ...}
+            software: !core/software-1.0.0 {name: asdf, version: ... }
         array: !core/ndarray-1.0.0
           source: 0
-          datatype: int64
+          datatype: int...
           byteorder: little
           shape: [5]
         my_var: [1, 2, 3]

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -490,34 +490,6 @@ class WeldxFile(UserDict):
         to call this method only with mode='rw', e.g. read-write mode. When mode is
         read-only, a temporary file will be created, which can cause in-efficiencies.
 
-        Examples
-        --------
-        >>> import numpy as np
-        >>> tree = dict(my_var=(1, 2, 3), some_str="foobar", array=np.arange(5))
-        >>> f = WeldxFile(tree=tree, mode='rw')
-        >>> f.show_asdf_header()  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        #ASDF 1.0.0
-        #ASDF_STANDARD 1.5.0
-        %YAML 1.1
-        %TAG ! tag:stsci.edu:asdf/
-        --- !core/asdf-1.1.0
-        asdf_library: !core/software-1.0.0 {author: The ASDF Developers,
-          homepage: 'http://github.com/asdf-format/asdf',
-          name: asdf, version: ... }
-        history:
-          extensions:
-          - !core/extension_metadata-1.0.0
-            extension_class: asdf.extension.BuiltinExtension
-            software: !core/software-1.0.0 {name: asdf, version: ... }
-        array: !core/ndarray-1.0.0
-          source: 0
-          datatype: int...
-          byteorder: little
-          shape: [5]
-        my_var: [1, 2, 3]
-        some_str: foobar
-        <BLANKLINE>
-
         """
         # We need to synchronize the file contents here to make sure the header is in
         # place.
@@ -550,9 +522,9 @@ class WeldxFile(UserDict):
                     return notebook_fileprinter(self.file_handle)
 
         def _impl_non_interactive():
-            with reset_file_position(self.file_handle):
-                out = get_yaml_header(self.file_handle, parse=False)
-                print(out)
+            from asdf import info
+
+            info(self._asdf_handle)
 
         # automatically determine if this runs in an interactive session.
         if _interactive is None:

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -8,8 +8,7 @@ from contextlib import contextmanager
 from io import BytesIO, IOBase
 from typing import IO, Dict, List, Mapping, Optional, Union
 
-from asdf import AsdfFile, generic_io
-from asdf import open as open_asdf
+from asdf import AsdfFile, generic_io, open as open_asdf
 from asdf import util
 from asdf.tags.core import Software
 from asdf.util import get_file_type
@@ -497,15 +496,27 @@ class WeldxFile(UserDict):
         >>> tree = dict(my_var=(1, 2, 3), some_str="foobar", array=np.arange(5))
         >>> f = WeldxFile(tree=tree, mode='rw')
         >>> f.show_asdf_header()  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        {'asdf_library': {'author': 'The ASDF Developers', \
-        'homepage': 'http://github.com/asdf-format/asdf', 'name': 'asdf',\
-         'version': '...'},
-         'history': {'extensions': [{'extension_class': \
-            'asdf.extension.BuiltinExtension', \
-            'software': {'name': 'asdf', 'version': '...'}}]}, \
-         'array': {'source': 0, 'datatype': 'int...', 'byteorder': 'little', \
-                   'shape': [5]}, \
-         'my_var': [1, 2, 3], 'some_str': 'foobar'}
+        #ASDF 1.0.0
+        #ASDF_STANDARD 1.5.0
+        %YAML 1.1
+        %TAG ! tag:stsci.edu:asdf/
+        --- !core/asdf-1.1.0
+        asdf_library: !core/software-1.0.0 {author: The ASDF Developers,
+          homepage: 'http://github.com/asdf-format/asdf',
+          name: asdf, version: ...}
+        history:
+          extensions:
+          - !core/extension_metadata-1.0.0
+            extension_class: asdf.extension.BuiltinExtension
+            software: !core/software-1.0.0 {name: asdf, version: ...}
+        array: !core/ndarray-1.0.0
+          source: 0
+          datatype: int64
+          byteorder: little
+          shape: [5]
+        my_var: [1, 2, 3]
+        some_str: foobar
+        <BLANKLINE>
 
         """
         # We need to synchronize the file contents here to make sure the header is in

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -538,9 +538,10 @@ class WeldxFile(UserDict):
                 else:
                     return notebook_fileprinter(self.file_handle)
 
-        def _impl_non_interactive() -> dict:
+        def _impl_non_interactive():
             with reset_file_position(self.file_handle):
-                return get_yaml_header(self.file_handle, parse=True)
+                out = get_yaml_header(self.file_handle, parse=False)
+                print(out)
 
         # automatically determine if this runs in an interactive session.
         if _interactive is None:
@@ -549,7 +550,7 @@ class WeldxFile(UserDict):
             else:
                 return self.show_asdf_header(_interactive=False)
         elif _interactive is False:
-            return _impl_non_interactive()
+            _impl_non_interactive()
         elif _interactive is True:
             return _impl_interactive()
 

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -3,6 +3,7 @@ import io
 import pathlib
 import shutil
 import tempfile
+from _curses import use_env
 from io import BytesIO
 
 import asdf
@@ -337,6 +338,18 @@ class TestWeldXFile:
         file.show_asdf_header()
         after_pos = file.file_handle.tell()
         assert old_pos == after_pos
+
+    @staticmethod
+    @pytest.mark.parametrize("mode", ("r", "rw"))
+    def test_show_header_in_sync(mode, capsys):
+        """Ensure that the updated tree is displayed in show_header"""
+        with WeldxFile(mode=mode) as fh:
+            fh["wx_user"] = dict(test=True)
+            fh.show_asdf_header(use_widgets=False, _interactive=False)
+
+        out, err = capsys.readouterr()
+        assert "wx_user" in out
+        assert "test" in out
 
     def test_invalid_software_entry(self):
         """Invalid software entries should raise."""

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -1,9 +1,7 @@
 """Tests for the WeldxFile class."""
-import io
 import pathlib
 import shutil
 import tempfile
-from _curses import use_env
 from io import BytesIO
 
 import asdf
@@ -78,7 +76,7 @@ def test_protocol_check(tmpdir):
 def simple_asdf_file(request):
     """Create an ASDF file with a very simple tree and attaches it to cls."""
     f = asdf.AsdfFile(tree=dict(wx_metadata=dict(welder="anonymous")))
-    buff = io.BytesIO()
+    buff = BytesIO()
     f.write_to(buff)
     request.cls.simple_asdf_file = buff
 


### PR DESCRIPTION
## Changes
In non interactive sessions the output was not printed, but simply returned. This made it harder to write code running in different environments. Now WeldxFile.show_asdf_header() prints.

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
