### PR TITLE
388 timeseries init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### changes
 
+- `TimeSeries.__init__` accepts `xarray.DataArray` as `data`
+  parameter [[#429]](https://github.com/BAMWelDX/weldx/pull/429)
+
 ### fixes
 
 ### documentation

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -352,11 +352,11 @@ class TimeSeries:
         if "time" != data_array.dims[0]:
             raise ValueError("The first dimension of the DataArray must be 'time'.")
 
-        if (time_coords := data_array.coords.get("time")) is None:
+        if "time" not in data_array.coords:
             raise ValueError("The 'DataArray' does not specify time values.")
 
         try:
-            ut.to_pandas_time_index(time_coords.data)
+            ut.to_pandas_time_index(data_array.coords.get("time").data)
         except TypeError:
             raise TypeError(
                 "The time values of the 'DataArray' must be convertible to a "

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -349,8 +349,8 @@ class TimeSeries:
     @staticmethod
     def _check_data_array(data_array: xr.DataArray):
         """Raise an exception if the 'DataArray' can't be used as 'self._data'."""
-        if "time" != data_array.dims[0]:
-            raise ValueError("The first dimension of the DataArray must be 'time'.")
+        if "time" not in data_array.dims:
+            raise ValueError("The 'DataArray' must have a dimension called 'time'.")
 
         if "time" not in data_array.coords:
             raise ValueError("The 'DataArray' does not specify time values.")
@@ -379,6 +379,10 @@ class TimeSeries:
 
         if isinstance(data, xr.DataArray):
             self._check_data_array(data)
+            if data.dims[0] != "time":
+                data = data.transpose(
+                    *ut.swap_list_items(data.dims, data.dims[0], "time")
+                )
             self._data = data
         else:
             # expand dim for scalar input

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -294,7 +294,7 @@ class TimeSeries:
         self._units = None
         self._interp_counter = 0
 
-        if isinstance(data, pint.Quantity):
+        if isinstance(data, (pint.Quantity, xr.DataArray)):
             self._initialize_discrete(data, time, interpolation)
         elif isinstance(data, MathematicalExpression):
             self._init_expression(data)
@@ -347,7 +347,7 @@ class TimeSeries:
 
     def _initialize_discrete(
         self,
-        data: pint.Quantity,
+        data: Union[pint.Quantity, xr.DataArray],
         time: Union[None, pd.TimedeltaIndex, pint.Quantity],
         interpolation: str,
     ):

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -375,8 +375,7 @@ class TimeSeries:
 
         if isinstance(data, xr.DataArray):
             self._check_data_array(data)
-            if data.dims[0] != "time":
-                data = data.transpose("time", ...)
+            data = data.transpose("time", ...)
             self._data = data
         else:
             # expand dim for scalar input

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -376,9 +376,7 @@ class TimeSeries:
         if isinstance(data, xr.DataArray):
             self._check_data_array(data)
             if data.dims[0] != "time":
-                data = data.transpose(
-                    *ut.swap_list_items(data.dims, data.dims[0], "time")
-                )
+                data = data.transpose("time", ...)
             self._data = data
         else:
             # expand dim for scalar input

--- a/weldx/core.py
+++ b/weldx/core.py
@@ -349,18 +349,14 @@ class TimeSeries:
     @staticmethod
     def _check_data_array(data_array: xr.DataArray):
         """Raise an exception if the 'DataArray' can't be used as 'self._data'."""
-        if "time" not in data_array.dims:
-            raise ValueError("The 'DataArray' must have a dimension called 'time'.")
-
-        if "time" not in data_array.coords:
-            raise ValueError("The 'DataArray' does not specify time values.")
-
         try:
-            ut.to_pandas_time_index(data_array.coords.get("time").data)
-        except TypeError:
-            raise TypeError(
-                "The time values of the 'DataArray' must be convertible to a "
-                "'pandas.TimedeltaIndex'."
+            ut.xr_check_coords(data_array, dict(time={"dtype": ["timedelta64[ns]"]}))
+        except (KeyError, TypeError, ValueError) as e:
+            raise type(e)(
+                "The provided 'DataArray' does not match the required pattern. It "
+                "needs to have a dimension called 'time' with coordinates of type "
+                "'timedelta64[ns]'. The error reported by the comparison function was:"
+                f"\n{e}"
             )
 
         if not isinstance(data_array.data, pint.Quantity):

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -308,6 +308,7 @@ class TestTimeSeries:
         ],
     )
     def test_init_data_array(data, dims, coords, exception_type):
+        """Test the `__init__` method with an xarray as data parameter."""
         da = xr.DataArray(data=data, dims=dims, coords=coords)
         if exception_type is not None:
             with pytest.raises(exception_type):

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pint
 import pytest
+import xarray as xr
 
 import weldx.util as ut
 from weldx.constants import WELDX_QUANTITY as Q_
@@ -291,6 +292,28 @@ class TestTimeSeries:
         assert ts.shape == shape_exp
         assert ts.data_array is None
         assert Q_(1, unit_exp).check(UREG.get_dimensionality(ts.units))
+
+    # test_init_data_array -------------------------------------------------------------
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "data, dims, coords, exception_type",
+        [
+            (Q_([1, 2, 3], "m"), "time", dict(time=TDI([1, 2, 3])), None),
+            (Q_([1, 2, 3], "m"), "a", dict(a=TDI([1, 2, 3])), ValueError),
+            (Q_([[1]], "m"), ("a", "time"), dict(a=[2], time=TDI([1])), ValueError),
+            (Q_([1, 2, 3], "m"), "time", None, ValueError),
+            (Q_([1, 2, 3], "m"), "time", dict(time=[1, 2, 3]), TypeError),
+            ([1, 2, 3], "time", dict(time=TDI([1, 2, 3])), TypeError),
+        ],
+    )
+    def test_init_data_array(data, dims, coords, exception_type):
+        da = xr.DataArray(data=data, dims=dims, coords=coords)
+        if exception_type is not None:
+            with pytest.raises(exception_type):
+                TimeSeries(da)
+        else:
+            TimeSeries(da)
 
     # test_construction_exceptions -----------------------------------------------------
 

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -300,9 +300,9 @@ class TestTimeSeries:
         "data, dims, coords, exception_type",
         [
             (Q_([1, 2, 3], "m"), "time", dict(time=TDI([1, 2, 3])), None),
-            (Q_([1, 2, 3], "m"), "a", dict(a=TDI([1, 2, 3])), ValueError),
+            (Q_([1, 2, 3], "m"), "a", dict(a=TDI([1, 2, 3])), KeyError),
             (Q_([[1, 2]], "m"), ("a", "time"), dict(a=[2], time=TDI([1, 2])), None),
-            (Q_([1, 2, 3], "m"), "time", None, ValueError),
+            (Q_([1, 2, 3], "m"), "time", None, KeyError),
             (Q_([1, 2, 3], "m"), "time", dict(time=[1, 2, 3]), TypeError),
             ([1, 2, 3], "time", dict(time=TDI([1, 2, 3])), TypeError),
         ],

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -301,7 +301,7 @@ class TestTimeSeries:
         [
             (Q_([1, 2, 3], "m"), "time", dict(time=TDI([1, 2, 3])), None),
             (Q_([1, 2, 3], "m"), "a", dict(a=TDI([1, 2, 3])), ValueError),
-            (Q_([[1]], "m"), ("a", "time"), dict(a=[2], time=TDI([1])), ValueError),
+            (Q_([[1, 2]], "m"), ("a", "time"), dict(a=[2], time=TDI([1, 2])), None),
             (Q_([1, 2, 3], "m"), "time", None, ValueError),
             (Q_([1, 2, 3], "m"), "time", dict(time=[1, 2, 3]), TypeError),
             ([1, 2, 3], "time", dict(time=TDI([1, 2, 3])), TypeError),
@@ -314,7 +314,8 @@ class TestTimeSeries:
             with pytest.raises(exception_type):
                 TimeSeries(da)
         else:
-            TimeSeries(da)
+            ts = TimeSeries(da)
+            assert ts.data_array.dims[0] == "time"
 
     # test_construction_exceptions -----------------------------------------------------
 


### PR DESCRIPTION
## Changes

`TimeSeries.__init__` accepts `xarray.DataArray` as `data` parameter.

## Related Issues

Closes #388 

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
- [x] ~~update example/tutorial notebooks~~
