### PR TITLE
move util functions to welding module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### changes
 
+- move `sine` utility function to `weldx.welding.util` [[#439]](https://github.com/BAMWelDX/weldx/pull/439)
+
 ### fixes
 
 ### documentation

--- a/tutorials/experiment_design_01.ipynb
+++ b/tutorials/experiment_design_01.ipynb
@@ -69,10 +69,9 @@
     "# importing the weldx package with prevalent default abbreviations\n",
     "import weldx\n",
     "import weldx.geometry as geo\n",
-    "import weldx.util as util\n",
-    "from weldx import Q_\n",
-    "from weldx.transformations import LocalCoordinateSystem as LCS\n",
-    "from weldx.welding.groove.iso_9692_1 import get_groove"
+    "from weldx import Q_, get_groove\n",
+    "from weldx import LocalCoordinateSystem as LCS\n",
+    "from weldx.welding.util import sine, lcs_coords_from_ts"
    ]
   },
   {
@@ -234,8 +233,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sine_y = util.sine(f=Q_(1, \"Hz\"), amp=Q_([[0, 1, 0]], \"mm\"))\n",
-    "coords = util.lcs_coords_from_ts(sine_y, time)\n",
+    "sine_y = sine(f=Q_(1, \"Hz\"), amp=Q_([[0, 1, 0]], \"mm\"))\n",
+    "coords = lcs_coords_from_ts(sine_y, time)\n",
     "csm.add_cs(\n",
     "    coordinate_system_name=\"tcp_sine_y\",\n",
     "    reference_system_name=\"tcp_wire\",\n",
@@ -256,8 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sine_z = util.sine(f=Q_(1, \"Hz\"), amp=Q_([[0, 0, 2]], \"mm\"), bias=Q_([0, 0, 0], \"mm\"))\n",
-    "coords = util.lcs_coords_from_ts(sine_z, time)\n",
+    "sine_z = sine(f=Q_(1, \"Hz\"), amp=Q_([[0, 0, 2]], \"mm\"), bias=Q_([0, 0, 0], \"mm\"))\n",
+    "coords = lcs_coords_from_ts(sine_z, time)\n",
     "csm.add_cs(\n",
     "    coordinate_system_name=\"tcp_sine_z\",\n",
     "    reference_system_name=\"tcp_wire\",\n",

--- a/tutorials/measurement_example.ipynb
+++ b/tutorials/measurement_example.ipynb
@@ -21,7 +21,8 @@
     "import weldx.measurement as msm\n",
     "import weldx.transformations as tf\n",
     "from weldx import Q_\n",
-    "from weldx import util"
+    "from weldx import util\n",
+    "from weldx.welding.util import sine"
    ]
   },
   {
@@ -57,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "I_ts = util.sine(f=Q_(10, \"1/s\"), amp=Q_(20, \"A\"), bias=Q_(300, \"A\"))\n",
+    "I_ts = sine(f=Q_(10, \"1/s\"), amp=Q_(20, \"A\"), bias=Q_(300, \"A\"))\n",
     "I = I_ts.interp_time(time)\n",
     "\n",
     "current_data = weldx.TimeSeries(data=I.data, time=time)\n",
@@ -70,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "U_ts = util.sine(f=Q_(10, \"1/s\"), amp=Q_(3, \"V\"), bias=Q_(40, \"V\"), phase=Q_(0.1, \"rad\"))\n",
+    "U_ts = sine(f=Q_(10, \"1/s\"), amp=Q_(3, \"V\"), bias=Q_(40, \"V\"), phase=Q_(0.1, \"rad\"))\n",
     "U = U_ts.interp_time(time)\n",
     "\n",
     "voltage_data = weldx.TimeSeries(data=U.data, time=time)\n",

--- a/tutorials/welding_example_02_weaving.ipynb
+++ b/tutorials/welding_example_02_weaving.ipynb
@@ -47,7 +47,10 @@
     "    get_groove,\n",
     "    util,\n",
     "    LinearHorizontalTraceSegment,\n",
-    ")"
+    "    welding,\n",
+    ")\n",
+    "\n",
+    "from weldx.welding.util import sine, lcs_coords_from_ts"
    ]
   },
   {
@@ -248,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts_sine = util.sine(f=Q_(0.5 * 2 * np.pi, \"Hz\"), amp=Q_([[0, 0.75, 0]], \"mm\"))"
+    "ts_sine = sine(f=Q_(0.5 * 2 * np.pi, \"Hz\"), amp=Q_([[0, 0.75, 0]], \"mm\"))"
    ]
   },
   {
@@ -484,7 +487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts_sine = util.sine(f=Q_(1 / 8 * 2 * np.pi, \"Hz\"), amp=Q_([[0, 0, 1]], \"mm\"))"
+    "ts_sine = sine(f=Q_(1 / 8 * 2 * np.pi, \"Hz\"), amp=Q_([[0, 0, 1]], \"mm\"))"
    ]
   },
   {
@@ -501,7 +504,7 @@
    "outputs": [],
    "source": [
     "t = pd.timedelta_range(start=\"0s\", end=\"8s\", freq=\"25ms\")\n",
-    "ts_sine_data = util.lcs_coords_from_ts(ts_sine, t)\n",
+    "ts_sine_data = lcs_coords_from_ts(ts_sine, t)\n",
     "tcp_sine2 = LocalCoordinateSystem(coordinates=ts_sine_data)"
    ]
   },
@@ -632,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/weldx/__init__.py
+++ b/weldx/__init__.py
@@ -17,10 +17,10 @@ except ModuleNotFoundError:  # pragma: no cover
 from weldx.constants import WELDX_QUANTITY as Q_
 
 # main modules
-import weldx.transformations  # import this first to avoid circular dependencies
 import weldx.util  # import this first to avoid circular dependencies
-import weldx.config
 import weldx.core
+import weldx.transformations
+import weldx.config
 import weldx.geometry
 import weldx.welding
 

--- a/weldx/__init__.py
+++ b/weldx/__init__.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:  # pragma: no cover
     )
 
 # constants - should be imported first, no internal weldx deps
-from weldx.constants import WELDX_QUANTITY as Q_
+from .constants import WELDX_QUANTITY as Q_
 
 # main modules
 import weldx.util  # import this first to avoid circular dependencies

--- a/weldx/asdf/cli/welding_schema.py
+++ b/weldx/asdf/cli/welding_schema.py
@@ -30,7 +30,6 @@ def single_pass_weld_example(
     import weldx
     import weldx.geometry as geo
     import weldx.measurement as msm
-    import weldx.util as ut
     from weldx import Q_, GmawProcess
     from weldx import LocalCoordinateSystem as lcs
     from weldx import TimeSeries, WXRotation, get_groove
@@ -41,6 +40,7 @@ def single_pass_weld_example(
     from weldx.asdf.tags.weldx.aws.process.shielding_gas_type import ShieldingGasType
     from weldx.asdf.util import get_schema_path, write_buffer
     from weldx.core import MathematicalExpression
+    from weldx.welding.util import sine
 
     # Timestamp
     reference_timestamp = pd.Timestamp("2020-11-09 12:00:00")
@@ -120,13 +120,11 @@ def single_pass_weld_example(
     time = pd.timedelta_range(start="0s", end="10s", freq="2s")
 
     # current data
-    I_ts = ut.sine(f=Q_(10, "1/s"), amp=Q_(20, "A"), bias=Q_(300, "A"))
+    I_ts = sine(f=Q_(10, "1/s"), amp=Q_(20, "A"), bias=Q_(300, "A"))
     current_data = TimeSeries(I_ts.interp_time(time).data, time)
 
     # voltage data
-    U_ts = ut.sine(
-        f=Q_(10, "1/s"), amp=Q_(3, "V"), bias=Q_(40, "V"), phase=Q_(0.1, "rad")
-    )
+    U_ts = sine(f=Q_(10, "1/s"), amp=Q_(3, "V"), bias=Q_(40, "V"), phase=Q_(0.1, "rad"))
     voltage_data = TimeSeries(U_ts.interp_time(time).data, time)
 
     # define current source and transformations

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -8,14 +8,15 @@ from contextlib import contextmanager
 from io import BytesIO, IOBase
 from typing import IO, Dict, List, Mapping, Optional, Union
 
-from asdf import AsdfFile, generic_io, open as open_asdf
+from asdf import AsdfFile, generic_io
+from asdf import open as open_asdf
 from asdf import util
 from asdf.tags.core import Software
 from asdf.util import get_file_type
 from jsonschema import ValidationError
 
 from weldx.asdf import WeldxAsdfExtension, WeldxExtension
-from weldx.asdf.util import get_schema_path, get_yaml_header, view_tree
+from weldx.asdf.util import get_schema_path, view_tree
 from weldx.types import SupportsFileReadWrite, types_file_like, types_path_and_file_like
 
 __all__ = [

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -345,7 +345,7 @@ class TestWeldXFile:
             fh["wx_user"] = dict(test=True)
             fh.show_asdf_header(use_widgets=False, _interactive=False)
 
-        out, err = capsys.readouterr()
+        out, _ = capsys.readouterr()
         assert "wx_user" in out
         assert "test" in out
 

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -21,7 +21,6 @@ from scipy.spatial.transform import Slerp
 
 from weldx.constants import WELDX_QUANTITY as Q_
 from weldx.constants import WELDX_UNIT_REGISTRY as ureg
-from weldx.core import MathematicalExpression, TimeSeries
 
 if TYPE_CHECKING:  # pragma: no cover
     import weldx.transformations as tf
@@ -226,74 +225,6 @@ def inherit_docstrings(cls):
                         f"could not derive docstring for {cls}.{name}", stacklevel=1
                     )
     return cls
-
-
-def sine(
-    f: Union[pint.Quantity, str],
-    amp: Union[pint.Quantity, str],
-    bias: Union[pint.Quantity, str] = None,
-    phase: Union[pint.Quantity, str] = Q_(0, "rad"),
-) -> TimeSeries:
-    """Create a simple sine TimeSeries from quantity parameters.
-
-    f(t) = amp*sin(f*t+phase)+bias
-
-    Parameters
-    ----------
-    f :
-        Frequency of the sine (in Hz)
-    amp :
-        Sine amplitude
-    bias :
-        function bias
-    phase :
-        phase shift
-
-    Returns
-    -------
-    TimeSeries
-
-    """
-    if bias is None:
-        amp = Q_(amp)
-        bias = 0.0 * amp.u
-    expr_string = "a*sin(o*t+p)+b"
-    parameters = {"a": amp, "b": bias, "o": Q_(2 * np.pi, "rad") * Q_(f), "p": phase}
-    expr = MathematicalExpression(expression=expr_string, parameters=parameters)
-    return TimeSeries(expr)
-
-
-@deprecated(
-    "0.4.1",
-    "0.5.0",
-    "The 'LocalCoordinateSystem' now supports 'TimeSeries' as coordinates rendering "
-    "this function obsolete.",
-)
-def lcs_coords_from_ts(
-    ts: TimeSeries, time: Union[pd.DatetimeIndex, pint.Quantity]
-) -> xr.DataArray:
-    """Create translation coordinates from a TimeSeries at specific timesteps.
-
-    Parameters
-    ----------
-    ts:
-        TimeSeries that describes the coordinate motion as a 3D vector.
-    time
-        Timestamps used for interpolation.
-        TODO: add support for pd.DateTimeindex as well
-
-    Returns
-    -------
-    xarray.DataArray :
-        A DataArray with correctly labeled dimensions to be used for LCS creation.
-
-    """
-    ts_data = ts.interp_time(time=time).data_array
-    # assign vector coordinates and convert to mm
-    ts_data = ts_data.rename({"dim_1": "c"}).assign_coords({"c": ["x", "y", "z"]})
-    ts_data.data = ts_data.data.to("mm").magnitude
-    ts_data["time"] = pd.TimedeltaIndex(ts_data["time"].data)
-    return ts_data
 
 
 def is_column_in_matrix(column, matrix) -> bool:

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -1,4 +1,6 @@
 """Contains package internal utility functions."""
+from __future__ import annotations
+
 import functools
 import json
 import sys
@@ -7,7 +9,7 @@ from collections.abc import Iterable, Sequence
 from functools import reduce, wraps
 from inspect import getmembers, isfunction
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Collection, Dict, List, Mapping, Union
+from typing import Any, Callable, Collection, Dict, List, Mapping, Union
 
 import numpy as np
 import pandas as pd
@@ -19,11 +21,8 @@ from pandas.api.types import is_datetime64_dtype, is_object_dtype, is_timedelta6
 from scipy.spatial.transform import Rotation as Rot
 from scipy.spatial.transform import Slerp
 
-from weldx.constants import WELDX_QUANTITY as Q_
-from weldx.constants import WELDX_UNIT_REGISTRY as ureg
-
-if TYPE_CHECKING:  # pragma: no cover
-    import weldx.transformations as tf
+from .constants import WELDX_QUANTITY as Q_
+from .constants import WELDX_UNIT_REGISTRY as ureg
 
 
 class WeldxDeprecationWarning(DeprecationWarning):
@@ -316,7 +315,6 @@ def to_pandas_time_index(
         pd.TimedeltaIndex,
         pd.DatetimeIndex,
         xr.DataArray,
-        "tf.LocalCoordinateSystem",
     ],
 ) -> Union[pd.TimedeltaIndex, pd.DatetimeIndex]:
     """Convert a time variable to the corresponding pandas time index type.

--- a/weldx/welding/util.py
+++ b/weldx/welding/util.py
@@ -2,13 +2,85 @@
 from typing import Union
 
 import numpy as np
+import pandas as pd
 import pint
+import xarray as xr
 
 from weldx import Q_
 from weldx.constants import WELDX_UNIT_REGISTRY
+from weldx.core import MathematicalExpression, TimeSeries
+from weldx.util import deprecated
 from weldx.welding.groove.iso_9692_1 import IsoBaseGroove
 
 __all__ = ["compute_welding_speed"]
+
+
+def sine(
+    f: Union[pint.Quantity, str],
+    amp: Union[pint.Quantity, str],
+    bias: Union[pint.Quantity, str] = None,
+    phase: Union[pint.Quantity, str] = Q_(0, "rad"),
+) -> TimeSeries:
+    """Create a simple sine TimeSeries from quantity parameters.
+
+    f(t) = amp*sin(f*t+phase)+bias
+
+    Parameters
+    ----------
+    f :
+        Frequency of the sine (in Hz)
+    amp :
+        Sine amplitude
+    bias :
+        function bias
+    phase :
+        phase shift
+
+    Returns
+    -------
+    TimeSeries
+
+    """
+    if bias is None:
+        amp = Q_(amp)
+        bias = 0.0 * amp.u
+    expr_string = "a*sin(o*t+p)+b"
+    parameters = {"a": amp, "b": bias, "o": Q_(2 * np.pi, "rad") * Q_(f), "p": phase}
+    expr = MathematicalExpression(expression=expr_string, parameters=parameters)
+    return TimeSeries(expr)
+
+
+@deprecated(
+    "0.4.1",
+    "0.5.0",
+    "The 'LocalCoordinateSystem' now supports 'TimeSeries' as coordinates rendering "
+    "this function obsolete.",
+)
+def lcs_coords_from_ts(
+    ts: TimeSeries, time: Union[pd.DatetimeIndex, pint.Quantity]
+) -> xr.DataArray:
+    """Create translation coordinates from a TimeSeries at specific timesteps.
+
+    Parameters
+    ----------
+    ts:
+        TimeSeries that describes the coordinate motion as a 3D vector.
+    time
+        Timestamps used for interpolation.
+        TODO: add support for pd.DateTimeindex as well
+
+    Returns
+    -------
+    xarray.DataArray :
+        A DataArray with correctly labeled dimensions to be used for LCS creation.
+
+    """
+    ts_data = ts.interp_time(time=time).data_array
+    # assign vector coordinates and convert to mm
+    ts_data = ts_data.rename({"dim_1": "c"}).assign_coords({"c": ["x", "y", "z"]})
+    ts_data.data = ts_data.data.to("mm").magnitude
+    ts_data["time"] = pd.TimedeltaIndex(ts_data["time"].data)
+    return ts_data
 
 
 @WELDX_UNIT_REGISTRY.check(None, "[length]/[time]", "[length]")


### PR DESCRIPTION
## Changes
move the `sine` utility function to `weldx.welding.util`

This is mostly to help avoid circular dependencies (no `core` dependencies in `weldx.util`)

## Related Issues

Closes # (add issue numbers)

## Checks

- [x] updated CHANGELOG.md
- [x] update example/tutorial notebooks 
