### PR TITLE
[csm/k3d-viz] downcast coordinates to float32

### DIFF
--- a/weldx/visualization/k3d_impl.py
+++ b/weldx/visualization/k3d_impl.py
@@ -289,6 +289,8 @@ class SpatialDataVisualizer:
         if isinstance(data, geo.SpatialData):
             triangles = data.triangles
             data = data.coordinates.data
+        # k3d needs single precision data.
+        data = data.astype(np.float32)
 
         self._reference_system = reference_system
 


### PR DESCRIPTION
## Changes

Internally k3d expects a single precision array for the coordinates and emits a warning. This is fixed by this change.
