### PR TITLE
[asdf] Do not copy array data

### DIFF
--- a/weldx/asdf/tags/weldx/core/common_types.py
+++ b/weldx/asdf/tags/weldx/core/common_types.py
@@ -134,7 +134,12 @@ class VariableTypeASDF(WeldxType):
 
         """
         dtype = np.dtype(tree["dtype"])
-        data = np.array(tree["data"], dtype=dtype)
+        # TODO: it would be ideal, if asdf would handle time types natively.
+        if dtype.char in ("M", "m"):  # handle np.timedelta64 and np.datetime64
+            data = np.array(tree["data"], dtype=dtype)
+            # assert data.base is tree["data"]
+        else:
+            data = tree["data"]  # let asdf handle np arrays with its own wrapper.
         if "unit" in tree:  # convert to pint.Quantity
             data = Q_(data, tree["unit"])
 

--- a/weldx/asdf/tags/weldx/core/data_array.py
+++ b/weldx/asdf/tags/weldx/core/data_array.py
@@ -1,3 +1,4 @@
+from asdf.tags.core import NDArrayType
 from xarray import DataArray
 
 import weldx.asdf.tags.weldx.core.common_types as ct
@@ -73,4 +74,7 @@ class XarrayDataArrayASDF(WeldxType):
         attrs = tree["attributes"]
 
         da = DataArray(data=data, coords=coords, dims=dims, attrs=attrs)
+        da.name = None  # we currently do not use the name attribute
+        # (but since it gets automatically derived if not set, we define it now.
+
         return da

--- a/weldx/asdf/tags/weldx/core/data_array.py
+++ b/weldx/asdf/tags/weldx/core/data_array.py
@@ -1,4 +1,3 @@
-from asdf.tags.core import NDArrayType
 from xarray import DataArray
 
 import weldx.asdf.tags.weldx.core.common_types as ct


### PR DESCRIPTION
## Changes

Because asdf does not handle time datatypes (correctly), there was a line of code within the serialization of xarray Variable to convert all ndarray like types from the asdf ndarray wrapper. This effectively prevents the use of the "copy_arrays" flag, since the
data got always copied.

## Related Issues

Closes #454

## Checks

- [ ] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
