### PR TITLE
use updated sphinx version, unpin jinja2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,7 +268,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "xarray": ("http://xarray.pydata.org/en/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "matplotlib": ("https://matplotlib.org", None),
     # "dask": ("https://docs.dask.org/en/latest", None),
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - ipykernel
   - ipywidgets
   # documentation
-  - sphinx>=4.1.1
-  - jinja2
+  - sphinx=4.0
+  - jinja2=2
   - m2r2
   - sphinxcontrib-napoleon
   - nbsphinx

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - ipykernel
   - ipywidgets
   # documentation
-  - sphinx=4.0
-  - jinja2=2
+  - sphinx>=4.1.1
+  - jinja2
   - m2r2
   - sphinxcontrib-napoleon
   - nbsphinx


### PR DESCRIPTION
## Changes
allow sphinx >4.0 again after logo fix in 4.1.1
4.1 should also support jinja3 so unpin

changed the scipy reference to new url

## Checks
- [x] updated doc/
