### PR TITLE
Merge and remove `LCS.from_`methods

### DIFF
--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -5,10 +5,11 @@ import platform
 import shutil
 import tempfile
 from io import BytesIO
-import xarray as xr
-import numpy as np
+
 import asdf
+import numpy as np
 import pytest
+import xarray as xr
 from jsonschema import ValidationError
 
 from weldx import WeldxFile
@@ -354,8 +355,9 @@ class TestWeldXFile:
 
         Also ensure the tree is still usable after showing the header.
         """
-        import psutil
         import gc
+
+        import psutil
 
         large_array = np.ones((1000, 1000), dtype=np.float64)  # ~7.6mb
         proc = psutil.Process()

--- a/weldx/welding/groove/iso_9692_1.py
+++ b/weldx/welding/groove/iso_9692_1.py
@@ -2,7 +2,7 @@
 import abc
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Tuple, Union, Dict
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pint


### PR DESCRIPTION
## Changes

Removes some `from_` methods from the LCS and replaces them with a generalized method. The same applies to the corresponding `create_` methods from the CSM

## Related Issues

Closes # (add issue numbers)

## Checks

- [ ] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks 
