### PR TITLE
Fix warnings

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,6 @@ test_patterns = [
 
 exclude_patterns = [
   "doc/**",
-  "versioneer.py",
   "scripts/**",
   "weldx/_version.py",
   "weldx/asdf/**",

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -7,7 +7,6 @@ excluded_files:
   - "docs*"
   - "environment.yml"
   - "tools*"
-  - "versioneer.py"
   - "weldx/_version.py"
 
 excluded_words:
@@ -24,7 +23,6 @@ excluded_words:
   - pytest
   - pydocstyle
   - matplotlib
-  - versioneer
   - isort
   - networkx
   - shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,6 @@ select = C,E,F,W,B,B950 # black formatting options
 per-file-ignores =
     aws_setup.py:E501
 exclude =
-    versioneer.py,
     __init__.py,
     doc/conf.py,
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     matplotlib >=3
     fs
     ipywidgets
-    k3d <=2.9
+    k3d !=2.10
     meshio
     psutil
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     matplotlib >=3
     fs
     ipywidgets
-    k3d
+    k3d <=2.9
     meshio
     psutil
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -1,13 +1,12 @@
 """`WeldxFile` wraps creation and updating of ASDF files and underlying files."""
 import pathlib
-import unittest.mock
 from collections import UserDict
 from collections.abc import MutableMapping
 from contextlib import contextmanager
 from io import BytesIO, IOBase
 from typing import IO, Dict, List, Mapping, Optional, Union
 
-from asdf import AsdfFile, generic_io, info
+from asdf import AsdfFile, generic_io
 from asdf import open as open_asdf
 from asdf import util
 from asdf.tags.core import Software
@@ -15,7 +14,7 @@ from asdf.util import get_file_type
 from jsonschema import ValidationError
 
 from weldx.asdf import WeldxAsdfExtension, WeldxExtension
-from weldx.asdf.util import get_schema_path, view_tree
+from weldx.asdf.util import get_schema_path, get_yaml_header, view_tree
 from weldx.types import SupportsFileReadWrite, types_file_like, types_path_and_file_like
 
 __all__ = [
@@ -582,8 +581,4 @@ class _HeaderVisualizer:
 
     @staticmethod
     def _show_non_interactive(buff: BytesIO):
-        with unittest.mock.patch(
-            "asdf.AsdfFile.blocks", new_callable=_DummyBlockManager
-        ):
-            with WeldxFile(buff) as wx:
-                info(wx._asdf_handle, show_values=True, max_rows=None)
+        print(get_yaml_header(buff))

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -386,7 +386,7 @@ class WeldxFile(UserDict):
         >>> wfa.wx_meta.welder
         'Nikolai Nikolajewitsch Benardos'
 
-        We can also change theh data easily
+        We can also change the data easily
         >>> wfa.wx_meta.welder = "Myself"
         >>> wfa.wx_meta.welder
         'Myself'

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -5,10 +5,11 @@ import platform
 import shutil
 import tempfile
 from io import BytesIO
-import xarray as xr
-import numpy as np
+
 import asdf
+import numpy as np
 import pytest
+import xarray as xr
 from jsonschema import ValidationError
 
 from weldx import WeldxFile
@@ -354,8 +355,9 @@ class TestWeldXFile:
 
         Also ensure the tree is still usable after showing the header.
         """
-        import psutil
         import gc
+
+        import psutil
 
         large_array = np.ones((1000, 1000), dtype=np.float64)  # ~7.6mb
         proc = psutil.Process()

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from copy import deepcopy
-from typing import TYPE_CHECKING, List, Tuple, Union, Any
+from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -855,7 +855,7 @@ def xr_3d_vector(data: np.ndarray, time: Time = None) -> xr.DataArray:
     xarray.DataArray
 
     """
-    if time is not None and np.array(data).ndim == 2:
+    if time is not None and data.ndim == 2:
         if isinstance(time, Time):
             time = time.as_pandas_index()
         da = xr.DataArray(

--- a/weldx/util.py
+++ b/weldx/util.py
@@ -24,6 +24,7 @@ from pint import DimensionalityError
 from scipy.spatial.transform import Rotation as Rot
 from scipy.spatial.transform import Slerp
 
+from weldx.constants import Q_
 from weldx.time import Time
 
 from .constants import WELDX_UNIT_REGISTRY as ureg
@@ -855,7 +856,7 @@ def xr_3d_vector(data: np.ndarray, time: Time = None) -> xr.DataArray:
     xarray.DataArray
 
     """
-    if time is not None and data.ndim == 2:
+    if time is not None and Q_(data).ndim == 2:
         if isinstance(time, Time):
             time = time.as_pandas_index()
         da = xr.DataArray(

--- a/weldx/welding/groove/iso_9692_1.py
+++ b/weldx/welding/groove/iso_9692_1.py
@@ -2,7 +2,7 @@
 import abc
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Tuple, Union, Dict
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pint

--- a/weldx/welding/util.py
+++ b/weldx/welding/util.py
@@ -6,8 +6,7 @@ import pandas as pd
 import pint
 import xarray as xr
 
-from weldx import Q_
-from weldx.constants import WELDX_UNIT_REGISTRY
+from weldx.constants import Q_, WELDX_UNIT_REGISTRY
 from weldx.core import MathematicalExpression, TimeSeries
 from weldx.util import deprecated
 from weldx.welding.groove.iso_9692_1 import IsoBaseGroove


### PR DESCRIPTION
## Changes
- Fixes array conversion warnings from tests
- small cleanup
- don't allow k3d==2.10.0 because of conda dependencies
- use plain yaml str output for `_show_non_interactive` instead of `asdf.info`