### PR TITLE
Update gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 on:
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
   # Trigger the workflow on push events on master and tags
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: build
 on:
-  # Run every Monday at 6am UTC
-  schedule:
-    - cron: '0 6 * * 1'
   # Trigger the workflow on push events on master and tags
   push:
     branches:
@@ -20,6 +17,9 @@ on:
   release:
     types:
       - created
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   conda:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   # Trigger the workflow on relevant pull request events
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'doc/**'
+      - '!.github/workflows/build.yml'
   # Trigger the workflow on all release created events (this could redirect to main conda channel)
   release:
     types:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: documentation
 on:
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
   # Trigger the workflow on push events on master
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,5 @@
 name: documentation
 on:
-  # Run every Monday at 6am UTC
-  schedule:
-    - cron: '0 6 * * 1'
   # Trigger the workflow on push events on master
   push:
     branches:
@@ -14,6 +11,9 @@ on:
   release:
     types:
       - created
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
-      - '.github/**'
+      - '.github/workflows/pytest.yml'
   pull_request:
     paths:
       - 'weldx/**'
-      - '.github/**'
+      - '.github/workflows/pytest.yml'
 
 jobs:
   pytest:
@@ -49,6 +49,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
+        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
         run: |
           pip install wheel
           pip install -e .[test]
@@ -63,7 +64,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request')
+        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,11 @@
 name: pytest
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'weldx/**'
+  pull_request:
+    paths:
+      - 'weldx/**'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,12 +1,6 @@
 name: pytest
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'weldx/**'
-      - 'tutorials/**'
-      - '.github/workflows/pytest.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
-      - '.github/workflows/pytest.yaml'
+      - '.github/**'
   pull_request:
     paths:
       - 'weldx/**'
-      - '.github/workflows/pytest.yaml'
+      - '.github/**'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
+      - '.github/workflows/pytest.yaml'
   pull_request:
     paths:
       - 'weldx/**'
+      - '.github/workflows/pytest.yaml'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,8 +1,5 @@
 name: pytest
 on:
-  # Run every Monday at 6am UTC
-  schedule:
-    - cron: '0 6 * * 1'
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -10,6 +7,9 @@ on:
       - 'weldx/**'
       - 'tutorials/**'
       - '.github/workflows/pytest.yml'
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
-        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) # || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pip install wheel
           pip install -e .[test]
@@ -66,7 +66,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) # || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,6 +61,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
+        if: (matrix.os == 'ubuntu-latest') || (${{ github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
-        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) # || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pip install wheel
           pip install -e .[test]
@@ -66,7 +66,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) # || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,7 +63,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: (matrix.os == 'ubuntu-latest') || ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master'}}
+        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         py: ['3.8', '3.9']
+    defaults:
+      if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -49,7 +51,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
-        if: (matrix.os == 'ubuntu-latest') || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pip install wheel
           pip install -e .[test]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,7 +55,7 @@ jobs:
           pip install -e .[test]
 
       - name: setup matplotlib
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && ((github.event_name == 'pull_request') || (github.ref == 'refs/heads/master'))
         run: |
             if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
             echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
@@ -64,7 +64,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,13 +1,17 @@
 name: pytest
 on:
   push:
+    branches:
+      - master
     paths:
       - 'weldx/**'
+      - 'tutorials/**'
       - '.github/workflows/pytest.yml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'weldx/**'
+      - 'tutorials/**'
       - '.github/workflows/pytest.yml'
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,8 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         py: ['3.8', '3.9']
-    defaults:
-      if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,13 +49,13 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: pip installs
-        if: (matrix.os == 'ubuntu-latest') || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
+        if: (matrix.os == 'ubuntu-latest') || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pip install wheel
           pip install -e .[test]
 
       - name: setup matplotlib
-        if: startsWith(runner.os, 'Windows') && ((github.event_name == 'pull_request') || (github.ref == 'refs/heads/master'))
+        if: startsWith(runner.os, 'Windows') && ((github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master'))
         run: |
             if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
             echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
@@ -64,7 +64,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
+        if: ((matrix.os == 'ubuntu-latest') && (matrix.py == '3.8')) || (github.event.pull_request.draft == false) || (github.ref == 'refs/heads/master')
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,7 +63,7 @@ jobs:
         shell: cmd
 
       - name: run pytest
-        if: (matrix.os == 'ubuntu-latest') || (${{ github.event_name == 'pull_request') || (github.ref == 'refs/heads/master')
+        if: (matrix.os == 'ubuntu-latest') || ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master'}}
         run: |
           pytest -n 2 --runslow --dist=loadfile
           echo "Exited with '$?'"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,8 @@
 name: pytest
 on:
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,7 @@ on:
       - 'weldx/**'
       - '.github/workflows/pytest.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'weldx/**'
       - '.github/workflows/pytest.yml'

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -1,14 +1,10 @@
 name: pytest asdf
 on:
   push:
-    paths:
-      - 'weldx/**'
-      - '.github/workflows/pytest_asdf.yml'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'weldx/**'
-      - '.github/workflows/pytest_asdf.yml'
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -1,5 +1,13 @@
 name: pytest asdf
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'weldx/**'
+      - '.github/workflows/pytest_asdf.yaml'
+  pull_request:
+    paths:
+      - 'weldx/**'
+      - '.github/workflows/pytest_asdf.yaml'
 
 jobs:
   pytest:

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -4,16 +4,12 @@ on: [push, pull_request]
 jobs:
   pytest:
     name: pytest asdf
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        py: ['3.8']
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.py }}
+          python-version: '3.8'
       - name: pip installs
         run: |
           pip install -e .[test]

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -5,6 +5,7 @@ on:
       - 'weldx/**'
       - '.github/workflows/pytest_asdf.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'weldx/**'
       - '.github/workflows/pytest_asdf.yml'

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
-      - '.github/workflows/pytest_asdf.yaml'
+      - '.github/workflows/pytest_asdf.yml'
   pull_request:
     paths:
       - 'weldx/**'
-      - '.github/workflows/pytest_asdf.yaml'
+      - '.github/workflows/pytest_asdf.yml'
 
 jobs:
   pytest:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
+      - '.github/workflows/static_analysis.yaml'
   pull_request:
     paths:
       - 'weldx/**'
+      - '.github/workflows/static_analysis.yaml'
 
 jobs:
   pydocstyle:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -3,11 +3,11 @@ on:
   push:
     paths:
       - 'weldx/**'
-      - '.github/workflows/static_analysis.yaml'
+      - '.github/workflows/static_analysis.yml'
   pull_request:
     paths:
       - 'weldx/**'
-      - '.github/workflows/static_analysis.yaml'
+      - '.github/workflows/static_analysis.yml'
 
 jobs:
   pydocstyle:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,20 +1,23 @@
 name: static analysis
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'weldx/**'
+  pull_request:
+    paths:
+      - 'weldx/**'
 
 jobs:
   pydocstyle:
     name: pydocstyle
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        py: ['3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.py }}
+          python-version: '3.8'
       - name: pip installs
         run: pip install pydocstyle
       - name: run pydocstyle
@@ -23,17 +26,14 @@ jobs:
 
   flake8:
     name: flake8
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        py: ['3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.py }}
+          python-version: '3.8'
       - name: pip installs
         run: pip install flake8==3.8.*
       - name: run flake8
@@ -42,18 +42,15 @@ jobs:
 
   isort:
     name: isort
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        py: ['3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.py }}
+          python-version: '3.8'
       - name: pip installs
         run: pip install isort==5.*
       - name: show isort diff
@@ -73,17 +70,14 @@ jobs:
 
   mypy:
     name: mypy
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        py: ['3.9']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.py }}
+          python-version: '3.9'
       - name: pip installs
         run: pip install mypy
       - name: run mypy

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -5,6 +5,7 @@ on:
       - 'weldx/**'
       - '.github/workflows/static_analysis.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'weldx/**'
       - '.github/workflows/static_analysis.yml'

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,14 +1,10 @@
 name: static analysis
 on:
   push:
-    paths:
-      - 'weldx/**'
-      - '.github/workflows/static_analysis.yml'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'weldx/**'
-      - '.github/workflows/static_analysis.yml'
+  # Run every Monday at 6am UTC
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   pydocstyle:

--- a/weldx/__init__.py
+++ b/weldx/__init__.py
@@ -25,7 +25,7 @@ import weldx.geometry
 import weldx.welding
 import weldx.time
 
-# class imports to weldx namespace DUMMY
+# class imports to weldx namespace
 from weldx.config import Config
 from weldx.core import MathematicalExpression, TimeSeries
 from weldx.geometry import (

--- a/weldx/__init__.py
+++ b/weldx/__init__.py
@@ -25,7 +25,7 @@ import weldx.geometry
 import weldx.welding
 import weldx.time
 
-# class imports to weldx namespace
+# class imports to weldx namespace DUMMY
 from weldx.config import Config
 from weldx.core import MathematicalExpression, TimeSeries
 from weldx.geometry import (


### PR DESCRIPTION
## Changes
My idea is do get the following:
- skip `pytest`, `pytest_asdf` & `static_analysis` workflows if no changes in `weldx/**` (or the workflow file itself)
- ONLY run the full pytest matrix on a 'ready for review PR'
  The full matrix will be started in other circumstances as well but all slow steps (pip install, pytest) on win & osx will simply be skipped. So the tests report running but finish after 10s or so.
  this also skips these matrix elements on fork branches (there, only the main pytest on ubuntu will run)
- skip the conda/pypi build CI for changes only in `CHANGELOG.md` or `doc/**`

One thing that is not so great is that the checks will get triggered again if you switch between draft and open PRs (which we usually don't do)

I also removed the os/python matrix where we only had a single entry.

## Related Issues

Closes #481 

