### PR TITLE
pin k3d in binder env

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - matplotlib
   - ipympl
   - nodejs
+  - k3d=2.9.7
   - pip:
     - git+https://github.com/BAMWelDX/weldx.git

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install required matplotlib JupyterLab extensions
-jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager k3d --debug
+jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager k3d@2.9.7 --debug
 jupyter lab build --minimize=False --debug
 
 python setup.py --version


### PR DESCRIPTION
## Changes
I noticed the k3d widgets were not loading on our main repo binder, pinning the package and labextension to the same version should hopefully fix this
