### PR TITLE
WeldxFile copy interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
   both submodules can still be accessed using `weldx.util` [[#490]](https://github.com/BAMWelDX/weldx/pull/490)
 - xarray implementations for the `LocalCoordinateSystem` now operate on time as a dimension instead of
   coordinates [[#486]](https://github.com/BAMWelDX/weldx/pull/486)
+- `WeldxFile.copy` now creates a copy to a (optional) file. Before it just returned a dictionary
+  [[#504]](https://github.com/BAMWelDX/weldx/pull/504).
+
 
 ### fixes
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -17,7 +17,6 @@ from jsonschema import ValidationError
 
 from weldx.types import SupportsFileReadWrite, types_file_like, types_path_and_file_like
 from weldx.util import inherit_docstrings
-
 from .util import get_schema_path, get_yaml_header, view_tree
 
 __all__ = [
@@ -340,7 +339,7 @@ class WeldxFile(UserDict):
             Optional software used to make the change.
 
         Notes
-        --------
+        -----
         The software entry will be inferred from the constructor or, if not defined,
         from ``software_history_entry``.
 
@@ -368,15 +367,49 @@ class WeldxFile(UserDict):
             raise RuntimeError("closed file, cannot access file handle.")
         return self._asdf_handle._fd._fd
 
-    def copy(self, filename_or_file_like: Optional[types_path_and_file_like] = None) -> "WeldxFile":
+    def copy(
+        self,
+        filename_or_file_like: Optional[types_path_and_file_like] = None,
+        overwrite: bool = False,
+    ) -> "WeldxFile":
+        """Take a copy of this file.
+
+        Depending on the underlying file type this does several different things.
+
+        Parameters
+        ----------
+        filename_or_file_like :
+            The desired output file. If no file is given, an in-memory file
+            will be created.
+        overwrite :
+            If `filename_or_file_like` points to a path or filename which already
+            exists, this flag determines if it would be overwritten or not.
+
+        Returns
+        -------
+        WeldxFile :
+            The new instance with the copied content.
+        """
+        # check if we would overwrite an existing path
+        if isinstance(filename_or_file_like, (str, pathlib.Path)):
+            try:
+                filename_or_file_like, _ = self._handle_path(
+                    filename_or_file_like, mode="rw"
+                )
+            except FileExistsError:
+                if not overwrite:
+                    raise
+
         file = self.write_to(filename_or_file_like)
-        wx = WeldxFile(file, mode=self.mode, custom_schema=self.custom_schema,
-                      asdffile_kargs=self._asdffile_kwargs,
-                      write_kwargs=self._write_kwargs,
-                      sync=self._sync,
-                      software_history_entry=self.software_history_entry,
-                      compression=self.compression,
-                      copy_arrays=self.copy_arrays)
+        wx = WeldxFile(
+            file,
+            mode=self.mode,
+            custom_schema=self.custom_schema,
+            asdffile_kwargs=self._asdffile_kwargs,
+            write_kwargs=self._write_kwargs,
+            sync=self.sync_upon_close,
+            software_history_entry=self.software_history_entry,
+        )
         return wx
 
     def as_attr(self) -> MutableMapping:
@@ -440,10 +473,8 @@ class WeldxFile(UserDict):
         The given input file name or a buffer, in case the input was omitted.
 
         """
-        created = False
         if fd is None:
             fd = BytesIO()
-            created = True
 
         # if no args are given, we use the specifications given in the constructor.
         if not write_args:
@@ -451,7 +482,7 @@ class WeldxFile(UserDict):
 
         self._asdf_handle.write_to(fd, **write_args)
 
-        if created:
+        if isinstance(fd, types_file_like.__args__):
             fd.seek(0)
         return fd
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -368,6 +368,17 @@ class WeldxFile(UserDict):
             raise RuntimeError("closed file, cannot access file handle.")
         return self._asdf_handle._fd._fd
 
+    def copy(self, filename_or_file_like: Optional[types_path_and_file_like] = None) -> "WeldxFile":
+        file = self.write_to(filename_or_file_like)
+        wx = WeldxFile(file, mode=self.mode, custom_schema=self.custom_schema,
+                      asdffile_kargs=self._asdffile_kwargs,
+                      write_kwargs=self._write_kwargs,
+                      sync=self._sync,
+                      software_history_entry=self.software_history_entry,
+                      compression=self.compression,
+                      copy_arrays=self.copy_arrays)
+        return wx
+
     def as_attr(self) -> MutableMapping:
         """Return the Weldx dictionary as an attributed object.
 


### PR DESCRIPTION
## Changes

copy creates a `WeldxFile` instance optionally with a new filename. If the optional filename already exists, it depends on the overwrite flag, if the `FileExistsError` is raised or not.

## Related Issues

Closes #493

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
