### PR TITLE
Use micromamba in Github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           # Increase this value to reset cache if ./devtools/conda.recipe/build_env.yml has not changed
           CACHE_NUMBER: 1
         with:
-          path: ~/conda_pkgs_dir
+          path: ~/micromamba/pkgs
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./devtools/conda.recipe/build_env.yml') }}
 
       - name: Setup Conda Environment
@@ -48,7 +48,7 @@ jobs:
 
       - name: activate build env
         shell: bash -l {0}
-        run: conda activate build_env
+        run: micromamba activate build_env
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,23 +62,6 @@ jobs:
         shell: bash -l {0}
         run: conda mambabuild .
 
-      - name: set package file env
-        shell: bash -l {0}
-        run: echo "PACKAGE_DIR=$(conda mambabuild . --output)" >> $GITHUB_ENV
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: weldx-conda
-          path: ${{ env.PACKAGE_DIR }}
-
-      - name: upload releases to dev label on Anaconda Cloud
-        if: github.event_name == 'release' && github.event.action == 'created'
-        shell: bash -l {0}
-        env: # set access token from GitHub secrets
-          anaconda_token: ${{ secrets.Anaconda_BAMwelding }}
-        run: |
-          anaconda -t $anaconda_token upload --user BAMwelding --label dev $PACKAGE_DIR
-
   pypi:
     if: github.event.pull_request.draft == false # exclude job from draft PR
     name: pypi build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,8 @@ jobs:
           environment-file: ./devtools/conda.recipe/build_env.yml
 
       - name: activate build env
-        shell: conda activate build_env
+        shell: bash -l {0}
+        run: conda activate build_env
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,12 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./devtools/conda.recipe/build_env.yml') }}
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@v10
         with:
           environment-file: ./devtools/conda.recipe/build_env.yml
-          activate-environment: build_env
-          auto-activate-base: false
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          channels: conda-forge, defaults
-          mamba-version: "*"
+
+      - name: activate build env
+        shell: conda activate build_env
 
       - name: conda info
         shell: bash -l {0}
@@ -65,7 +63,7 @@ jobs:
 
       - name: set package file env
         shell: bash -l {0}
-        run: echo "PACKAGE_DIR=$(conda build . --output)" >> $GITHUB_ENV
+        run: echo "PACKAGE_DIR=$(conda mambabuild . --output)" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,14 +35,14 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./doc/rtd_environment.yml', './setup.cfg') }}
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@v10
         with:
           environment-file: ./doc/rtd_environment.yml
-          activate-environment: weldx
-          auto-activate-base: false
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          channels: conda-forge, defaults
-          mamba-version: "*"
+          environment-name: rtd
+
+      - name: activate build env
+        shell: bash -l {0}
+        run: micromamba activate rtd
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,10 +56,6 @@ jobs:
         shell: bash -l {0}
         run: ipython kernel install --user --name=weldx
 
-      - name: develop install
-        shell: bash -l {0}
-        run: pip install -e .
-
       - name: Build docs
         shell: bash -l {0}
         run: sphinx-build -W -n -b html -d build/doctrees doc build/html --keep-going

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,12 @@ jobs:
         shell: bash -l {0}
         run: micromamba activate rtd
 
+      - name: install dev version again
+        # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
+        # So the initial env creation lacks weldx, so we install it here.
+        shell: bash -l {0}
+        run: pwd && pip install -e . && pip install git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
+
       - name: conda info
         shell: bash -l {0}
         run: conda info

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     matplotlib >=3
     fs
     ipywidgets
-    k3d !=2.10
+    k3d <=2.9
     meshio
     psutil
 include_package_data = True


### PR DESCRIPTION
## Changes

the miniconda action takes almost 3 minutes to setup mamba itself. So we switch to a preinstalled version of mamba.