### PR TITLE
set pint default unit format to short notation

### DIFF
--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -14,6 +14,8 @@ WELDX_UNIT_REGISTRY = _ureg(
 WELDX_UNIT_REGISTRY.define("percent = 0.01*count = %")
 # swap plank constant for hour definition
 WELDX_UNIT_REGISTRY.define("hour = 60*minute = h = hr")
+# set default string format to short notation
+WELDX_UNIT_REGISTRY.default_format = "~"
 
 WELDX_QUANTITY = WELDX_UNIT_REGISTRY.Quantity
 Q_ = WELDX_QUANTITY

--- a/weldx/tags/unit/pint_quantity.py
+++ b/weldx/tags/unit/pint_quantity.py
@@ -21,7 +21,7 @@ class PintQuantityConverter(WeldxConverter):
         if not value.shape:
             value = value.item()  # convert scalars to native Python numeric types
         tree["value"] = value
-        tree["unit"] = str(obj.units)
+        tree["unit"] = f"{obj.units:.}"  # use 'long' formatting for serialization
         return tree
 
     def from_yaml_tree(self, node: dict, tag: str, ctx):


### PR DESCRIPTION
## Changes
use `pint` short notation for units as default

I encountered some problems with serialization using short notation (not sure why), so explicitly keeping the long notation there

## Related Issues

Closes # (add issue numbers)

## Checks

- [ ] updated CHANGELOG.md
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
