### PR TITLE
add get_highest_tag_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   and `CoordinateSystemManager.create_cs_from_axis_vectors` [[#472]](https://github.com/BAMWelDX/weldx/pulls/472)
 - added PyTest flags to use ``WeldxFile`` internally in ``asdf.util.read_buffer`` and ``asdf.util.write_buffer``
   [[#469]](https://github.com/BAMWelDX/weldx/pull/469).
+- added `weldx.asdf.util.get_highest_tag_version` utility function [[#523]](https://github.com/BAMWelDX/weldx/pull/523).
 
 ### removed
 
@@ -47,7 +48,6 @@
   coordinates [[#486]](https://github.com/BAMWelDX/weldx/pull/486)
 - `WeldxFile.copy` now creates a copy to a (optional) file. Before it just returned a dictionary
   [[#504]](https://github.com/BAMWelDX/weldx/pull/504).
-
 
 ### fixes
 

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -55,6 +55,7 @@ py:meth scipy.stats.special_ortho_group
 py:obj mrp[i]
 
 # asdf
+py:class asdf.asdf.SerializationContext
 py:class iterable of asdf.extension.Compressor instances
 py:class See the class docstring for details on keyword
 py:class iterable of str

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -13,6 +13,8 @@ from asdf.tagged import TaggedDict
 from asdf.util import uri_match as asdf_uri_match
 from boltons.iterutils import get_path
 
+from weldx.asdf.constants import SCHEMA_PATH, WELDX_EXTENSION_URI
+from weldx.asdf.types import WeldxConverter
 from weldx.types import (
     SupportsFileReadOnly,
     SupportsFileReadWrite,
@@ -21,9 +23,6 @@ from weldx.types import (
     types_path_like,
 )
 from weldx.util import deprecated
-
-from .constants import SCHEMA_PATH, WELDX_EXTENSION_URI
-from .types import WeldxConverter
 
 _USE_WELDX_FILE = False
 _INVOKE_SHOW_HEADER = False
@@ -499,6 +498,12 @@ def get_highest_tag_version(
     ------
     ValueError
         When the pattern matches multiple base tags in in the extension.
+
+    Examples
+    --------
+    >>> from weldx.asdf.util import get_highest_tag_version
+    >>> get_highest_tag_version("asdf://weldx.bam.de/weldx/tags/uuid-*")
+    'asdf://weldx.bam.de/weldx/tags/uuid-1.0.0'
 
     """
     if ctx is None:

--- a/weldx/tests/asdf_tests/test_asdf_util.py
+++ b/weldx/tests/asdf_tests/test_asdf_util.py
@@ -8,6 +8,7 @@ import pytest
 from weldx import WeldxFile
 from weldx.asdf.util import (
     dataclass_serialization_class,
+    get_highest_tag_version,
     get_yaml_header,
     read_buffer,
     write_buffer,
@@ -154,3 +155,15 @@ def test_write_buffer_dummy_inline_arrays():
     restored = read_buffer(buff)[name]
     assert restored.dtype == array.dtype
     assert restored.shape == array.shape
+
+
+def test_get_highest_tag_version():
+    """Test getting some tags from the WeldxExtension."""
+    assert (
+        get_highest_tag_version("asdf://weldx.bam.de/weldx/tags/uuid-*")
+        == "asdf://weldx.bam.de/weldx/tags/uuid-1.0.0"
+    )
+    assert get_highest_tag_version("asdf://weldx.bam.de/weldx/tags/uuid-2.*") is None
+
+    with pytest.raises(ValueError):
+        get_highest_tag_version("asdf://weldx.bam.de/weldx/tags/**-*")


### PR DESCRIPTION
## Changes
- add `get_highest_tag_version` utility function
  The function looks for the currently active weldx extension by default (should be fast thanks to asdf caching)

## Related Issues
Closes #483

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] updated doc/
