### PR TITLE
units refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@
   [[#494]](https://github.com/BAMWelDX/weldx/pull/494).
 - `compare_nested` can compare sets [[#496]](https://github.com/BAMWelDX/weldx/pull/496)
 - `WeldxFile` cleans old memory blocks during file updates [[#539]](https://github.com/BAMWelDX/weldx/pull/539).
-- `WeldxFile` respects `mode` argument also for BytesIO and file handles [[#539]](https://github.com/BAMWelDX/weldx/pull/539).
+- `WeldxFile` respects `mode` argument also for BytesIO and file
+  handles [[#539]](https://github.com/BAMWelDX/weldx/pull/539).
 
 ### documentation
 
@@ -98,7 +99,10 @@
   [[#497]](https://github.com/BAMWelDX/weldx/pull/497)
 - add ``asdf://weldx.bam.de/weldx/schemas/unit/quantity``
   and ``asdf://weldx.bam.de/weldx/schemas/unit/unit`` schemas [[#522]](https://github.com/BAMWelDX/weldx/pull/522).
-- use ``asdf://weldx.bam.de/weldx/schemas/unit/quantity`` instead of ``tag:stsci.edu:asdf/unit/quantity-1.1.0`` [[#542]](https://github.com/BAMWelDX/weldx/pull/542).
+- use ``asdf://weldx.bam.de/weldx/schemas/unit/quantity`` instead
+  of ``tag:stsci.edu:asdf/unit/quantity-1.1.0`` [[#542]](https://github.com/BAMWelDX/weldx/pull/542).
+- refactor properties named ``unit`` to ``units`` and use ``unit/unit``
+  tag [[#551]](https://github.com/BAMWelDX/weldx/pull/551).
 
 ### deprecations
 

--- a/tutorials/measurement_chain.ipynb
+++ b/tutorials/measurement_chain.ipynb
@@ -178,7 +178,7 @@
     "source_2 = SignalSource(\n",
     "    name=\"Source\",\n",
     "    error=Error(Q_(0.1, \"percent\")),\n",
-    "    output_signal=Signal(signal_type=\"analog\", unit=\"V\"),\n",
+    "    output_signal=Signal(signal_type=\"analog\", units=\"V\"),\n",
     ")"
    ]
   },
@@ -584,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/tutorials/measurement_example.ipynb
+++ b/tutorials/measurement_example.ipynb
@@ -149,7 +149,7 @@
     "current_source = msm.SignalSource(\n",
     "    name=\"Current sensor\",\n",
     "    error=msm.Error(Q_(0.1, \"percent\")),\n",
-    "    output_signal=msm.Signal(signal_type=\"analog\", unit=\"V\"),\n",
+    "    output_signal=msm.Signal(signal_type=\"analog\", units=\"V\"),\n",
     ")\n",
     "\n",
     "HKS_sensor.sources.append(current_source)"
@@ -360,7 +360,7 @@
     "voltage_source = msm.SignalSource(\n",
     "    name=\"Voltage sensor\",\n",
     "    error=msm.Error(Q_(0.1, \"percent\")),\n",
-    "    output_signal=msm.Signal(signal_type=\"analog\", unit=\"V\"),\n",
+    "    output_signal=msm.Signal(signal_type=\"analog\", units=\"V\"),\n",
     ")\n",
     "\n",
     "HKS_sensor.sources.append(voltage_source)\n",
@@ -525,7 +525,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/tutorials/timeseries_01.ipynb
+++ b/tutorials/timeseries_01.ipynb
@@ -383,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/weldx/asdf/cli/welding_schema.py
+++ b/weldx/asdf/cli/welding_schema.py
@@ -131,7 +131,7 @@ def single_pass_weld_example(
 
     src_current = msm.SignalSource(
         name="Current Sensor",
-        output_signal=msm.Signal(signal_type="analog", unit="V", data=None),
+        output_signal=msm.Signal(signal_type="analog", units="V", data=None),
         error=msm.Error(Q_(0.1, "percent")),
     )
 

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -93,7 +93,10 @@ def _unit_validator(
     if not position:
         position = instance
 
-    unit = instance["unit"]
+    if "units" in instance:
+        unit = instance["units"]
+    else:  # legacy_code
+        unit = instance["unit"]
     valid = Q_(unit).check(UREG.get_dimensionality(expected_dimensionality))
     if not valid:
         yield ValidationError(

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -3,6 +3,8 @@ from pathlib import Path as _Path
 
 from pint import UnitRegistry as _ureg
 
+UNIT_KEY = "units"  # default nomenclature for storing physical units information
+
 WELDX_PATH = _Path(__file__).parent.resolve()
 
 WELDX_UNIT_REGISTRY = _ureg(
@@ -48,4 +50,5 @@ __all__ = (
     "WELDX_UNIT_REGISTRY",
     "Q_",
     "U_",
+    "UNIT_KEY",
 )

--- a/weldx/manifests/weldx-0.1.0.yaml
+++ b/weldx/manifests/weldx-0.1.0.yaml
@@ -59,6 +59,10 @@ tags:
   schema_uri: http://weldx.bam.de/schemas/weldx/core/transformations/local_coordinate_system-1.0.0
 - tag_uri: tag:weldx.bam.de:weldx/core/transformations/rotation-1.0.0
   schema_uri: http://weldx.bam.de/schemas/weldx/core/transformations/rotation-1.0.0
+- tag_uri: tag:weldx.bam.de:weldx/core/transformations/coordinate_system_hierarchy_subsystem-1.0.0
+  schema_uri: http://weldx.bam.de/schemas/weldx/core/transformations/coordinate_system_hierarchy_subsystem-1.0.0
+- tag_uri: tag:weldx.bam.de:weldx/core/transformations/coordinate_transformation-1.0.0
+  schema_uri: http://weldx.bam.de/schemas/weldx/core/transformations/coordinate_transformation-1.0.0
 - tag_uri: tag:weldx.bam.de:weldx/debug/test_property_tag-1.0.0
   schema_uri: http://weldx.bam.de/schemas/weldx/debug/test_property_tag-1.0.0
 - tag_uri: tag:weldx.bam.de:weldx/debug/test_shape_validator-1.0.0

--- a/weldx/measurement.py
+++ b/weldx/measurement.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union  # noqa: F401
 from warnings import warn
 
+import pint
 from networkx import draw, draw_networkx_edge_labels
 
 from weldx.constants import Q_, U_
@@ -33,13 +34,14 @@ class Signal:
     """Simple dataclass implementation for measurement signals."""
 
     signal_type: str
-    unit: str
+    units: pint.Quantity
     data: TimeSeries = None
 
     def __post_init__(self):
         """Perform some checks after construction."""
         if self.signal_type not in ["analog", "digital"]:
             raise ValueError(f"{self.signal_type} is an invalid signal type.")
+        self.units = U_(self.units)
 
     def plot(
         self,
@@ -476,8 +478,8 @@ class MeasurementChain:
             signal_type=cls._determine_output_signal_type(
                 transformation.type_transformation, input_signal.signal_type
             ),
-            unit=cls._determine_output_signal_unit(
-                transformation.func, input_signal.unit
+            units=cls._determine_output_signal_unit(
+                transformation.func, input_signal.units
             ),
             data=data,
         )
@@ -817,7 +819,7 @@ class MeasurementChain:
             warn("The created transformation does not perform any transformations.")
 
         input_signal_source = self._check_and_get_node_name(input_signal_source)
-        input_signal = self._graph.nodes[input_signal_source]["signal"]
+        input_signal: Signal = self._graph.nodes[input_signal_source]["signal"]
         if output_signal_type is None:
             output_signal_type = input_signal.signal_type
         type_tf = f"{input_signal.signal_type[0]}{output_signal_type[0]}".upper()
@@ -825,14 +827,14 @@ class MeasurementChain:
             if func is not None:
                 if not ureg.is_compatible_with(
                     output_signal_unit,
-                    self._determine_output_signal_unit(func, input_signal.unit),
+                    self._determine_output_signal_unit(func, input_signal.units),
                 ):
                     raise ValueError(
                         "The unit of the provided functions output has not the same "
                         f"dimensionality as {output_signal_unit}"
                     )
             else:
-                unit_conversion = U_(output_signal_unit) / U_(input_signal.unit)
+                unit_conversion = U_(output_signal_unit) / U_(input_signal.units)
                 func = MathematicalExpression(
                     "a*x",
                     parameters={"a": Q_(1, unit_conversion)},
@@ -966,8 +968,8 @@ class MeasurementChain:
 
         # walk over the graphs nodes and collect necessary data for plotting
         while True:
-            signal = graph.nodes[c_node]["signal"]
-            signal_labels[c_node] = f"{signal.signal_type}\n[{signal.unit}]"
+            signal: Signal = graph.nodes[c_node]["signal"]
+            signal_labels[c_node] = f"{signal.signal_type}\n[{signal.units}]"
             positions[c_node] = (x_pos, 0.75)
 
             if signal.data is not None:

--- a/weldx/measurement.py
+++ b/weldx/measurement.py
@@ -34,7 +34,7 @@ class Signal:
     """Simple dataclass implementation for measurement signals."""
 
     signal_type: str
-    units: pint.Quantity
+    units: pint.Unit
     data: TimeSeries = None
 
     def __post_init__(self):
@@ -245,7 +245,7 @@ class MeasurementChain:
         >>> current_source = SignalSource(name="Current sensor",
         ...                               error=Error(Q_(0.1, "percent")),
         ...                               output_signal=Signal(signal_type="analog",
-        ...                                                    unit="V")
+        ...                                                    units="V")
         ...                               )
 
         Create a measurement chain using the source
@@ -332,7 +332,7 @@ class MeasurementChain:
         >>> current_source = SignalSource(name="Current sensor",
         ...                               error=Error(Q_(0.1, "percent")),
         ...                               output_signal=Signal(signal_type="analog",
-        ...                                                    unit="V")
+        ...                                                    units="V")
         ...                               )
 
         Create the equipment

--- a/weldx/schemas/weldx.bam.de/weldx/aws/process/gas_component-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/aws/process/gas_component-0.1.0.yaml
@@ -14,7 +14,7 @@ examples:
     - |
       !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
         gas_chemical_name: argon
-        gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+        gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_for_procedure-0.1.0.yaml
@@ -18,12 +18,12 @@ examples:
             gas_component:
             - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
               gas_chemical_name: argon
-              gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
             - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
               gas_chemical_name: carbon dioxide
-              gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
             common_name: SG
-          torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
+          torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_type-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/aws/process/shielding_gas_type-0.1.0.yaml
@@ -17,10 +17,10 @@ examples:
         gas_component:
         - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
           gas_chemical_name: argon
-          gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+          gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
         - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
           gas_chemical_name: carbon dioxide
-          gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+          gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
         common_name: SG
 
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/core/mathematical_expression-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/mathematical_expression-0.1.0.yaml
@@ -18,8 +18,8 @@ examples:
       !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
         expression: a*x + b
         parameters:
-          a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
-          b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3.4, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
+          a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
+          b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3.4, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
@@ -47,11 +47,11 @@ oneOf:
           - type: number
           - type: integer
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-      unit:
+      units:
         description: |
           Unit of the data.
-        type: string
-    required: [value, unit]
+        tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
+    required: [value, units]
 
   - type: object
     description: |
@@ -61,15 +61,15 @@ oneOf:
         description: |
           A mathematical expression that describes the time dependent behaviour.
         tag: "asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.*"
-      unit:
+      units:
         description: |
           Resulting unit of the data when the expression is evaluated.
-        type: string
+        tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
       shape:
         description: |
           (optional) Resulting shape of the data when the expression is evaluated.
         type: array
-    required: [expression, unit]
+    required: [expression, units]
 
   - type: object
     description: |
@@ -79,10 +79,10 @@ oneOf:
         description: |
           A set of time deltas.
         tag: "asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.*"
-      unit:
+      units:
         description: |
-          Unit of the data.
-        type: string
+          Units of the data.
+        tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
       shape:
         description: |
           Shape of the data.
@@ -101,8 +101,8 @@ oneOf:
       #  The outer dimension of the data needs to be identical to the times dimension.
       time: [t]
       values: [t, ...]
-    required: [time, unit, shape, interpolation, values]
+    required: [time, units, shape, interpolation, values]
 
-propertyOrder: [expression, values, time, unit, shape, interpolation, values]
+propertyOrder: [expression, values, time, units, shape, interpolation, values]
 flowStyle: block
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
@@ -23,15 +23,15 @@ examples:
           expression: a*sin(o*t + p) + b
           parameters:
             a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0>
-              unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm
               value: !core/ndarray-1.0.0
                 data:
                 - [0, 0, 1]
                 datatype: int32
                 shape: [1, 3]
-            b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-            o: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4.934802200544679, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz * rad}
-            p: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> radian}
+            b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+            o: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4.934802200544679, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz * rad}
+            p: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> radian}
         unit: millimeter
         shape: [1, 3]
 

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
@@ -13,7 +13,7 @@ examples:
     - A time_series describing a constant value in time.
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-        unit: millimeter / second
+        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm / s
         value: 10.0
   -
     - A time_series describing a sine oscillation in 3d space along the z-axis
@@ -32,7 +32,7 @@ examples:
             b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
             o: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4.934802200544679, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz * rad}
             p: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> radian}
-        unit: millimeter
+        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm
         shape: [1, 3]
 
 oneOf:

--- a/weldx/schemas/weldx.bam.de/weldx/core/transformations/rotation-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/transformations/rotation-0.1.0.yaml
@@ -14,7 +14,7 @@ examples:
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.0>
         angles: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0>
-          unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg
+          units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg
           value: !core/ndarray-1.0.0
             data: [10.0, 20.0, 60.0]
             datatype: float64

--- a/weldx/schemas/weldx.bam.de/weldx/core/variable-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/variable-0.1.0.yaml
@@ -29,16 +29,16 @@ properties:
     oneOf:
       - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       - type: number
-  unit:
+  units:
     description: |
-      Optional field describing the unit of the data as valid string representation.
-    type: string
+      Optional field describing the unit of the data.
+    tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
   attrs:
     description: |
       Additional attributes metadata associated with the variable.
     type: object
 
 required: [name, dimensions, dtype, data]
-propertyOrder: [name, dimensions, dtype, unit, data]
+propertyOrder: [name, dimensions, dtype, units, data]
 flowStyle: block
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -284,14 +284,14 @@ examples:
               signal_type: analog
               unit: V
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
           - &id011 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
             name: Voltage Sensor
             output_signal: &id012 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
               signal_type: analog
               unit: V
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
           transformations: []
         - &id005 !<asdf://weldx.bam.de/weldx/tags/equipment/measurement_equipment-0.1.0>
           name: Beckhoff ELM3002-0000
@@ -300,22 +300,22 @@ examples:
           - &id006 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
             name: AD conversion current measurement
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
             func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
               expression: a*x + b
               parameters:
-                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
-                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
+                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
+                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
             type_transformation: AD
           - &id013 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
             name: AD conversion voltage measurement
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
             func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
               expression: a*x + b
               parameters:
-                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
-                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
+                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
+                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
             type_transformation: AD
         measurements:
         - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
@@ -368,8 +368,8 @@ examples:
                           func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                             expression: a*x + b
                             parameters:
-                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.030517578125, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
-                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
+                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
+                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
@@ -431,8 +431,8 @@ examples:
                           func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                             expression: a*x + b
                             parameters:
-                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0030517578125, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
-                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
+                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
+                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
@@ -451,12 +451,12 @@ examples:
               gas_component:
               - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
                 gas_chemical_name: argon
-                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
               - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
                 gas_chemical_name: carbon dioxide
-                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
               common_name: SG
-            torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
+            torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
           weld_speed: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
             unit: millimeter / second
             value: 10
@@ -483,7 +483,7 @@ examples:
             power_source: Quinto
             tag: CLOOS/pulse
           welding_wire:
-            diameter: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+            diameter: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         reference_timestamp: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> {value: '2020-11-09T12:00:00'}
         welding_current: *id015
         welding_voltage: *id016
@@ -491,11 +491,11 @@ examples:
           base_metal: {common_name: S355J2+N, standard: 'DIN EN 10225-2:2011'}
           geometry:
             groove_shape: !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/VGroove-0.1.0>
-              t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-              alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 50, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-              c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+              t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+              alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 50, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+              c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
               code_number: ['1.3', '1.5']
-            seam_length: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 300, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+            seam_length: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 300, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         wx_metadata: {welder: A.W. Elder}
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -282,14 +282,14 @@ examples:
             name: Current Sensor
             output_signal: &id004 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
               signal_type: analog
-              unit: V
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
               deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
           - &id011 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
             name: Voltage Sensor
             output_signal: &id012 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
               signal_type: analog
-              unit: V
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
             error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
               deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
           transformations: []
@@ -333,7 +333,7 @@ examples:
               freq: 2S
               min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M0S}
               max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M10S}
-            unit: ampere
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
             shape: [6]
             interpolation: step
             *id001 : *id002
@@ -356,7 +356,7 @@ examples:
                     attributes:
                       signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                         signal_type: digital
-                        unit: dimensionless
+                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''
                     edges:
                     - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                       direction: fwd
@@ -378,7 +378,7 @@ examples:
                         attributes:
                           signal: &id015 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                             signal_type: digital
-                            unit: ampere
+                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
                             data: *id007
             source_equipment: *id008
         - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
@@ -396,7 +396,7 @@ examples:
               freq: 2S
               min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M0S}
               max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M10S}
-            unit: volt
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
             shape: [6]
             interpolation: step
             *id009 : *id010
@@ -419,7 +419,7 @@ examples:
                     attributes:
                       signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                         signal_type: digital
-                        unit: dimensionless
+                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''
                     edges:
                     - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                       direction: fwd
@@ -441,7 +441,7 @@ examples:
                         attributes:
                           signal: &id016 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                             signal_type: digital
-                            unit: volt
+                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
                             data: *id014
             source_equipment: *id008
         process:
@@ -458,7 +458,7 @@ examples:
               common_name: SG
             torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
           weld_speed: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-            unit: millimeter / second
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm / s
             value: 10
           welding_process: !<asdf://weldx.bam.de/weldx/tags/process/CLOOS/pulse-0.1.0>
             base_process: pulse
@@ -466,19 +466,19 @@ examples:
             meta: {modulation: UI}
             parameters:
               base_current: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                unit: ampere
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
                 value: 60.0
               pulse_duration: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                unit: millisecond
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ms
                 value: 5.0
               pulse_frequency: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                unit: hertz
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz
                 value: 100.0
               pulse_voltage: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                unit: volt
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
                 value: 40.0
               wire_feedrate: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                unit: meter / minute
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm / min
                 value: 10.0
             power_source: Quinto
             tag: CLOOS/pulse

--- a/weldx/schemas/weldx.bam.de/weldx/equipment/measurement_equipment-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/equipment/measurement_equipment-0.1.0.yaml
@@ -21,12 +21,12 @@ examples:
           name: AD conversion current measurement
           type_transformation: AD
           error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-            deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+            deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
           func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
             expression: a*x + b
             parameters:
-              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
-              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
+              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
+              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DHUGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DHUGroove-0.1.0.yaml
@@ -11,15 +11,15 @@ examples:
     - A simple DHU-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/DHUGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 32, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 10, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        R2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 32, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 10, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        R2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['2.11']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DHVGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DHVGroove-0.1.0.yaml
@@ -11,13 +11,13 @@ examples:
     - A simple DHV-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/DHVGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 11, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 35, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 11, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 35, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: [2.9.1, 2.9.2]
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DUGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DUGroove-0.1.0.yaml
@@ -11,15 +11,15 @@ examples:
     - A simple DU-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/DUGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 33, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        R2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 33, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        beta_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        R2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['2.7']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DVGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/DVGroove-0.1.0.yaml
@@ -11,13 +11,13 @@ examples:
     - A simple DV-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/DVGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 19, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 40, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        alpha_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 19, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 40, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        alpha_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['2.4', 2.5.1, 2.5.2]
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/FFGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/FFGroove-0.1.0.yaml
@@ -11,50 +11,50 @@ examples:
     - A code 1.12 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: '1.12'
   -
     - A code 3.1.1 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 7, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: 3.1.1
   -
     - A code 3.1.2 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: 3.1.2
   -
     - A code 3.1.3 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: 3.1.3
   -
     - A code 4.1.2 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        e: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 80, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        e: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: 4.1.2
   -
     - A code 4.1.3 FF-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/FFGroove-0.1.0>
-        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_1: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t_2: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: 4.1.3
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/HUGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/HUGroove-0.1.0.yaml
@@ -11,11 +11,11 @@ examples:
     - A simple HU-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/HUGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['1.11', '2.10']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/HVGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/HVGroove-0.1.0.yaml
@@ -11,10 +11,10 @@ examples:
     - A simple HV-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/HVGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 9, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 55, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 9, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 55, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: [1.9.1, 1.9.2, '2.8']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/IGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/IGroove-0.1.0.yaml
@@ -11,8 +11,8 @@ examples:
     - A simple I-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/IGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: [1.2.1, 1.2.2, '2.1']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/UGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/UGroove-0.1.0.yaml
@@ -11,11 +11,11 @@ examples:
     - A simple U-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/UGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 9, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 9, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['1.8']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/UVGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/UVGroove-0.1.0.yaml
@@ -11,12 +11,12 @@ examples:
     - A simple UV-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/UVGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 11, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 60, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 11, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        R: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 6, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 4, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['1.6']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/VGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/VGroove-0.1.0.yaml
@@ -11,10 +11,10 @@ examples:
     - A simple V-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/VGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 40, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 15, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 40, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['1.3', '1.5']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/VVGroove-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/iso_9692_1_2013_12/VVGroove-0.1.0.yaml
@@ -11,12 +11,12 @@ examples:
     - A simple VV-Groove
     - |
       !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/VVGroove-0.1.0>
-        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 70, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 13, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        h: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 12, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 70, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        beta: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 13, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
+        b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+        h: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
         code_number: ['1.7']
 
 type: object

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/error-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/error-0.1.0.yaml
@@ -13,7 +13,7 @@ examples:
     - An error representing a deviation of 0.1%.
     - |
       !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-        deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+        deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/measurement_chain-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/measurement_chain-0.1.0.yaml
@@ -25,7 +25,7 @@ example:
             signal_type: analog
             unit: V
           error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-            deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.2, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+            deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
         graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
           root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
             name: Current sensor
@@ -38,11 +38,11 @@ example:
                 transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
                   name: AD conversion
                   error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-                    deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.025, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+                    deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.025, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
                   func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                     expression: a*x
                     parameters:
-                      a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
+                      a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
                   type_transformation: AD
               target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                 name: AD conversion
@@ -57,12 +57,12 @@ example:
                     transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
                       name: Calibration
                       error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-                        deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+                        deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
                       func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                         expression: a*x + b
                         parameters:
-                          a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 75, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
-                          b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 25, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
+                          a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 75, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
+                          b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 25, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
                       type_transformation: DD
                   target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                     name: Calibration

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/signal-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/signal-0.1.0.yaml
@@ -13,13 +13,13 @@ examples:
     - |
       !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
         signal_type: analog
-        unit: V
+        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
   -
     - A digital dimensionless signal.
     - |
       !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
         signal_type: digital
-        unit: ''
+        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''
 
 properties:
   signal_type:

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/signal-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/signal-0.1.0.yaml
@@ -27,17 +27,17 @@ properties:
       The type of the signal (analog or digital).
     type: string
     enum: [analog, digital]
-  unit:
+  units:
     description: |
       The unit of the signal (volt, kelvin, etc.).
-    type: string
+    tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
   data:
     description: |
       Measurement data that was produced by the signal.
     tag: "asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"
 
 
-propertyOrder: [signal_type, unit, data]
-required: [signal_type, unit]
+propertyOrder: [signal_type, units, data]
+required: [signal_type, units]
 flowStyle: block
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/signal_transformation-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/signal_transformation-0.1.0.yaml
@@ -15,7 +15,7 @@ examples:
       !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
         name: AD conversion
         error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%', value: 0.5 }
+          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%', value: 0.5 }
         type_transformation: AD
   -
     - A transformation that calculates amperes based on volts using a given function
@@ -23,12 +23,12 @@ examples:
       !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
         name: Volt-Ampere-Conversion
         error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%', value: 1.5 }
+          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%', value: 1.5 }
         func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
           expression: a*x + b
           parameters:
-            a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A / V, value: 3 }
-            b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A, value: 2 }
+            a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A / V, value: 3 }
+            b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> { units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A, value: 2 }
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/source-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/source-0.1.0.yaml
@@ -16,7 +16,7 @@ examples:
           signal_type: analog
           unit: V
         error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+          deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
 
 type: object
 properties:

--- a/weldx/schemas/weldx.bam.de/weldx/measurement/source-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/measurement/source-0.1.0.yaml
@@ -14,7 +14,7 @@ examples:
         name: Current Sensor
         output_signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
           signal_type: analog
-          unit: V
+          units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
         error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
           deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
 

--- a/weldx/schemas/weldx.bam.de/weldx/process/GMAW-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/process/GMAW-0.1.0.yaml
@@ -16,19 +16,19 @@ examples:
           meta: {modulation: UI}
           parameters:
             base_current: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-              unit: ampere
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
               value: 60.0
             pulse_duration: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-              unit: millisecond
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ms
               value: 5.0
             pulse_frequency: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-              unit: hertz
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz
               value: 100.0
             pulse_voltage: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-              unit: volt
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
               value: 40.0
             wire_feedrate: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-              unit: meter / minute
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> m / min
               value: 10.0
           power_source: Quinto
           tag: CLOOS/pulse
@@ -40,10 +40,10 @@ examples:
         manufacturer: CLOOS
         parameters:
           characteristic: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-            unit: volt / ampere
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V / A
             value: 5.0
           impedance: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-            unit: percent
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'
             value: 10.0
           voltage: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
             &id001 values: &id002 !core/ndarray-1.0.0
@@ -59,12 +59,12 @@ examples:
               end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M10S}
               min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M0S}
               max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> {value: P0DT0H0M10S}
-            unit: volt
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
             shape: [2]
             interpolation: linear
             *id001 : *id002
           wire_feedrate: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-            unit: meter / minute
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> m / min
             value: 10.0
         power_source: Quinto
         tag: CLOOS/spray_arc

--- a/weldx/schemas/weldx.bam.de/weldx/unit/quantity-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/unit/quantity-0.1.0.yaml
@@ -41,10 +41,10 @@ properties:
     oneOf:
       - type: number
       - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
-  unit:
+  units:
     description: |
       The unit corresponding to the values
     tag: "asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.*"
-required: [value, unit]
-propertyOrder: [value, unit]
+required: [value, units]
+propertyOrder: [value, units]
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/unit/quantity-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/unit/quantity-0.1.0.yaml
@@ -15,13 +15,13 @@ examples:
     - |
         !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0>
           value: 3.14159
-          unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> km
+          units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> km
   -
     - A quantity with an array of values
     - |
         !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0>
           value: !core/ndarray-1.0.0 [1, 2, 3, 4]
-          unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
+          units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
   -
     - A quantity with an n-dimensional array of values
     - |
@@ -30,7 +30,7 @@ examples:
             datatype: float64
             data: [[1, 2, 3],
                    [4, 5, 6]]
-          unit: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> m / s
+          units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> m / s
 
 
 type: object

--- a/weldx/tags/core/common_types.py
+++ b/weldx/tags/core/common_types.py
@@ -73,7 +73,7 @@ class VariableConverter(WeldxConverter):
     def to_yaml_tree(self, obj: Variable, tag: str, ctx) -> dict:
         """Convert to python dict."""
         if isinstance(obj.data, pint.Quantity):
-            unit = str(obj.data.units)
+            unit = obj.data.units
             data = obj.data.magnitude
         else:
             unit = None
@@ -90,7 +90,7 @@ class VariableConverter(WeldxConverter):
             "attrs": obj.attrs if obj.attrs else None,
         }
         if unit:
-            tree["unit"] = unit
+            tree["units"] = unit
 
         return tree
 
@@ -103,7 +103,10 @@ class VariableConverter(WeldxConverter):
             # assert data.base is tree["data"]
         else:
             data = node["data"]  # let asdf handle np arrays with its own wrapper.
-        if "unit" in node:  # convert to pint.Quantity
+
+        if "units" in node:  # convert to pint.Quantity
+            data = Q_(data, node["units"])
+        elif "unit" in node:  # legacy_code
             data = Q_(data, node["unit"])
 
         attrs = node.get("attrs", None)

--- a/weldx/tags/core/transformations/_legacy/coordinate_system_hierarchy.py
+++ b/weldx/tags/core/transformations/_legacy/coordinate_system_hierarchy.py
@@ -21,7 +21,7 @@ class CoordinateTransformationConverter(WeldxConverter):
     """Legacy serialization class for CoordinateTransformation"""
 
     tags = [
-        "tag:weldx.bam.de:weldx/core/transformations/coordinate_transformation-0.1.*"
+        "tag:weldx.bam.de:weldx/core/transformations/coordinate_transformation-1.0.0"
     ]
     types = [CoordinateTransformation]
 
@@ -65,7 +65,7 @@ class CoordinateSystemManagerSubsystemConverter(WeldxConverter):
 
     tags = [
         "tag:weldx.bam.de:weldx/core/transformations/"
-        "coordinate_system_hierarchy_subsystem-0.1.*"
+        "coordinate_system_hierarchy_subsystem-1.0.0"
     ]
     types = [CoordinateSystemManagerSubsystem]
 
@@ -96,7 +96,7 @@ class CoordinateSystemManagerConverter(WeldxConverter):
     """Legacy serialization class for weldx.transformations.CoordinateSystemManager"""
 
     tags = [
-        "tag:weldx.bam.de:weldx/core/transformations/coordinate_system_hierarchy-0.1.*"
+        "tag:weldx.bam.de:weldx/core/transformations/coordinate_system_hierarchy-1.0.0"
     ]
     types = [_CoordinateSystemManager]
 

--- a/weldx/tags/measurement/signal.py
+++ b/weldx/tags/measurement/signal.py
@@ -4,11 +4,12 @@ from weldx.measurement import Signal
 __all__ = ["Signal", "SignalConverter"]
 
 
-def _from_yaml_tree_mod(tree):
+def _from_yaml_tree_mod(tree: dict):
     if "data" not in tree:
         tree["data"] = None
     if "unit" in tree:  # legacy_code
         tree["units"] = tree["unit"]
+        tree.pop("unit")
     return tree
 
 

--- a/weldx/tags/measurement/signal.py
+++ b/weldx/tags/measurement/signal.py
@@ -7,6 +7,8 @@ __all__ = ["Signal", "SignalConverter"]
 def _from_yaml_tree_mod(tree):
     if "data" not in tree:
         tree["data"] = None
+    if "unit" in tree:  # legacy_code
+        tree["units"] = tree["unit"]
     return tree
 
 

--- a/weldx/tests/asdf_tests/test_asdf_measurement.py
+++ b/weldx/tests/asdf_tests/test_asdf_measurement.py
@@ -47,7 +47,7 @@ def measurement_chain_with_equipment() -> MeasurementChain:
     """Get a default measurement chain with attached equipment."""
     source = SignalSource(
         "Current measurement",
-        output_signal=Signal(signal_type="analog", unit="V"),
+        output_signal=Signal(signal_type="analog", units="V"),
         error=Error(Q_(1, "percent")),
     )
     ad_conversion = SignalTransformation(

--- a/weldx/tests/test_measurement.py
+++ b/weldx/tests/test_measurement.py
@@ -236,7 +236,7 @@ class TestMeasurementChain:
 
         signal = mc.output_signal
         assert signal.signal_type == exp_signal_type
-        assert U_(signal.unit) == exp_signal_unit
+        assert U_(signal.units) == exp_signal_unit
 
     # test_add_transformation_exceptions -----------------------------------------------
 


### PR DESCRIPTION
## Changes
refactor `unit` -> `units` in schemas

also serialize as `unit/unit` instead of string

## Related Issues

Closes #550

## Checks

- [x] updated CHANGELOG.md
- [x] updated tests
- [x] update example/tutorial notebooks
- [x] update manifest file
