### PR TITLE
add  `Δ°` pint preprocessor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Release Notes
 added
 ~~~~~
 
--  added “units” (exact) and “dimensionality” (dimensionality
+-  added "units" (exact) and “dimensionality” (dimensionality
    compatible) checking options to `util.xr_check_coords`
    `[#442] <https://github.com/BAMWelDX/weldx/pull/442>`__
 -  `Time` class that can be initialized from several other time types
@@ -27,6 +27,8 @@ added
    `[#437] <https://github.com/BAMWelDX/weldx/pulls/437>`__.
 -  added `weldx.asdf.util.get_highest_tag_version` utility function
    `[#523] <https://github.com/BAMWelDX/weldx/pull/523>`__.
+-  added support for parsing temperature deltas with ``Δ°`` notation
+   `[#565] <https://github.com/BAMWelDX/weldx/pull/565>`__.
 
 removed
 ~~~~~~~

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -8,8 +8,7 @@ from asdf.util import uri_match
 
 from weldx.asdf.types import WxSyntaxError
 from weldx.asdf.util import _get_instance_shape
-from weldx.constants import Q_
-from weldx.constants import WELDX_UNIT_REGISTRY as UREG
+from weldx.constants import U_
 
 __all__ = ["wx_unit_validator", "wx_shape_validator", "wx_property_tag_validator"]
 
@@ -97,7 +96,8 @@ def _unit_validator(
         unit = instance["units"]
     else:  # legacy_code
         unit = instance["unit"]
-    valid = Q_(unit).check(UREG.get_dimensionality(expected_dimensionality))
+    unit = str(unit)  # catch TaggedString
+    valid = U_(unit).is_compatible_with(U_(expected_dimensionality))
     if not valid:
         yield ValidationError(
             f"Error validating unit dimension for property '{position}'. "

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -8,7 +8,10 @@ UNIT_KEY = "units"  # default nomenclature for storing physical units informatio
 WELDX_PATH = _Path(__file__).parent.resolve()
 
 WELDX_UNIT_REGISTRY = _ureg(
-    preprocessors=[lambda string: string.replace("%", "percent")],  # allow %-sign
+    preprocessors=[
+        lambda string: string.replace("%", "percent"),  # allow %-sign
+        lambda string: string.replace("Δ°", "delta_deg"),  # parse Δ° for temperature
+    ],
     force_ndarray_like=True,
 )
 

--- a/weldx/schemas/weldx.bam.de/weldx/debug/test_unit_validator-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/debug/test_unit_validator-0.1.0.yaml
@@ -50,7 +50,12 @@ properties:
         type: string
     wx_unit: "m"
 
-required: [length_prop, velocity_prop, current_prop]
+  delta_prop:
+    description: simple property with temperature deltas
+    tag: "asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.*"
+    wx_unit: "Δ°C"
+
+required: [length_prop, velocity_prop, current_prop, delta_prop]
 propertyOrder: [length_prop, velocity_prop, current_prop]
 flowStyle: block
 additionalProperties: true
@@ -60,4 +65,5 @@ wx_unit:
   current_prop: A
   nested_prop:
     q2: "m*mm*cm"
+  delta_prop: "delta_degF"
 ...

--- a/weldx/tags/debug/test_unit_validator.py
+++ b/weldx/tags/debug/test_unit_validator.py
@@ -20,6 +20,7 @@ class UnitValidatorTestClass:
         default_factory=lambda: dict(q1=Q_(np.eye(3, 3), "m"), q2=Q_(2, "m^3"))
     )
     simple_prop: dict = field(default_factory=lambda: dict(value=float(3), unit="m"))
+    delta_prop: dict = Q_(100, "Δ°C")
 
 
 UnitValidatorTestClassConverter = dataclass_serialization_class(

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -7,8 +7,7 @@ import pint
 import pytest
 import xarray as xr
 
-from weldx.constants import Q_
-from weldx.constants import WELDX_UNIT_REGISTRY as UREG
+from weldx.constants import Q_, U_
 from weldx.core import MathematicalExpression, TimeSeries
 from weldx.tests._helpers import get_test_name
 from weldx.time import Time
@@ -240,7 +239,7 @@ class TestTimeSeries:
             (Q_([3, 7, 1], ""), Q_([0, 1, 2], "s"), "step", (3,)),
         ],
     )
-    def test_construction_discrete(data, time, interpolation, shape_exp):
+    def test_construction_discrete(data: pint.Quantity, time, interpolation, shape_exp):
         """Test the construction of the TimeSeries class."""
         # set expected values
         time_exp = time
@@ -248,7 +247,7 @@ class TestTimeSeries:
             time_exp = pd.TimedeltaIndex(time_exp.m, unit="s")
 
         exp_interpolation = interpolation
-        if len(data.m.shape) == 0 and interpolation is None:
+        if len(data.shape) == 0 and interpolation is None:
             exp_interpolation = "step"
 
         # create instance
@@ -259,7 +258,7 @@ class TestTimeSeries:
         assert np.all(ts.time == time_exp)
         assert ts.interpolation == exp_interpolation
         assert ts.shape == shape_exp
-        assert data.check(UREG.get_dimensionality(ts.units))
+        assert data.is_compatible_with(ts.units)
 
         assert np.all(ts.data_array.data == data)
         assert ts.data_array.attrs["interpolation"] == exp_interpolation
@@ -291,7 +290,7 @@ class TestTimeSeries:
         assert ts.interpolation is None
         assert ts.shape == shape_exp
         assert ts.data_array is None
-        assert Q_(1, unit_exp).check(UREG.get_dimensionality(ts.units))
+        assert U_(unit_exp).is_compatible_with(ts.units)
 
     # test_init_data_array -------------------------------------------------------------
 


### PR DESCRIPTION
## Changes
- add text preprocessor for handling `Δ°` in unit notation

I have tested it for  `Δ°C`, `Δ°F` and `Δ°Re` but I think we should stick to the long serialization format for now @marscher @vhirtham 
