### PR TITLE
set boa>=0.6 for local build

### DIFF
--- a/devtools/conda.recipe/build_env.yml
+++ b/devtools/conda.recipe/build_env.yml
@@ -9,6 +9,6 @@ dependencies:
   - conda-verify
   - conda-build
   - mamba
-  - boa
+  - boa>=0.6
   - anaconda-client
   - numpydoc>=0.5


### PR DESCRIPTION
## Changes
fix conda build environment for mamba 0.16
