### PR TITLE
Update single-pass weld schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,9 +115,9 @@ changes
    serialization still uses long notation (`[#560]
    <https://github.com/BAMWelDX/weldx/pull/560>`__))
 
--  `welding_current` and `welding_voltage` in the single-pass weld schema
-   now expect the tag `"asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"`
-   instead of `"asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.*"` `[#578]
+-  ``welding_current`` and ``welding_voltage`` in the single-pass weld schema
+   now expect the tag ``"asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"``
+   instead of ``"asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.*"`` `[#578]
    <https://github.com/BAMWelDX/weldx/pull/578>`__.
 
 fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,6 +115,11 @@ changes
    serialization still uses long notation (`[#560]
    <https://github.com/BAMWelDX/weldx/pull/560>`__))
 
+-  `welding_current` and `welding_voltage` in the single-pass weld schema
+   now expect the tag `"asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"`
+   instead of `"asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.*"` `[#578]
+   <https://github.com/BAMWelDX/weldx/pull/578>`__.
+
 fixes
 =====
 

--- a/weldx/asdf/cli/welding_schema.py
+++ b/weldx/asdf/cli/welding_schema.py
@@ -281,10 +281,10 @@ def single_pass_weld_example(
         measurements=[welding_current, welding_voltage],
         welding_current=welding_current_chain.get_signal(
             "Calibration current measurement"
-        ),
+        ).data,
         welding_voltage=welding_voltage_chain.get_signal(
             "Calibration voltage measurement"
-        ),
+        ).data,
         coordinate_systems=csm,
         TCP=TCP_reference,
         workpiece=workpiece,

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -167,17 +167,6 @@ examples:
     - A simple welding application
     - |
       !<tag:stsci.edu:asdf/core/asdf-1.1.0>
-        asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
-          name: asdf, version: 2.8.1}
-        history:
-          extensions:
-          - !core/extension_metadata-1.0.0
-            extension_class: asdf.extension.BuiltinExtension
-            software: !core/software-1.0.0 {name: asdf, version: 2.8.1}
-          - !core/extension_metadata-1.0.0
-            extension_class: weldx.asdf.extension.WeldxExtension
-            extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.0
-            software: !core/software-1.0.0 {name: weldx, version: 0.4.2.dev34+gf6e3c49.d20210820}
         TCP: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
           time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
             values: !core/ndarray-1.0.0

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -82,12 +82,12 @@ properties:
   welding_current:
     description: |
       The signal representing the welding current measurement.
-    tag: "asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.*"
+    tag: "asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"
     wx_unit: "A"
   welding_voltage:
     description: |
       The signal representing the welding voltage measurement.
-    tag: "asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.*"
+    tag: "asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.*"
     wx_unit: "V"
   TCP:
     description: |

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -178,17 +178,17 @@ examples:
             extension_class: weldx.asdf.extension.WeldxExtension
             extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.0
             software: !core/software-1.0.0 {name: weldx, version: 0.4.2.dev34+gf6e3c49.d20210820}
-        TCP: !weldx!core/transformations/local_coordinate_system-0.1.0
-          time: !weldx!time/timedeltaindex-0.1.0
+        TCP: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
+          time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
             values: !core/ndarray-1.0.0
               data: [0, 29000000000]
               datatype: int64
               shape: [2]
-            start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
-            end: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
-            min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
-            max: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
-          orientations: !weldx!core/variable-0.1.0
+            start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
+            end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
+            min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
+            max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
+          orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
             name: orientations
             dimensions: [c, v]
             dtype: <f8
@@ -199,7 +199,7 @@ examples:
               - [0.0, 1.2246467991473532e-16, -1.0]
               datatype: float64
               shape: [3, 3]
-          coordinates: !weldx!core/variable-0.1.0
+          coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
             name: coordinates
             dimensions: [time, c]
             dtype: <f8
@@ -209,39 +209,39 @@ examples:
               - [295.0, 1.2246467991473533e-15, 12.0]
               datatype: float64
               shape: [2, 3]
-        coordinate_systems: !weldx!core/transformations/coordinate_system_hierarchy-0.1.0
+        coordinate_systems: !<asdf://weldx.bam.de/weldx/tags/core/transformations/coordinate_system_hierarchy-0.1.0>
           name: Coordinate system manager 0
-          graph: !weldx!core/graph/di_graph-0.1.0
-            root_node: !weldx!core/graph/di_node-0.1.0
+          graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
+            root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
               name: base
               attributes:
                 data: {}
               edges:
-              - !weldx!core/graph/di_edge-0.1.0
+              - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                 direction: bwd
                 attributes:
                   defined: true
-                  transformation: !weldx!core/transformations/local_coordinate_system-0.1.0 {}
-                target_node: !weldx!core/graph/di_node-0.1.0
+                  transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0> {}
+                target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                   name: workpiece
                   attributes:
                     data: {}
                   edges:
-                  - !weldx!core/graph/di_edge-0.1.0
+                  - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                     direction: bwd
                     attributes:
                       defined: true
-                      transformation: !weldx!core/transformations/local_coordinate_system-0.1.0
-                        time: !weldx!time/timedeltaindex-0.1.0
+                      transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
+                        time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
                           values: !core/ndarray-1.0.0
                             data: [0, 29000000000]
                             datatype: int64
                             shape: [2]
-                          start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
-                          end: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
-                          min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
-                          max: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
-                        orientations: !weldx!core/variable-0.1.0
+                          start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
+                          end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
+                          min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
+                          max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
+                        orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
                           name: orientations
                           dimensions: [c, v]
                           dtype: <f8
@@ -252,7 +252,7 @@ examples:
                             - [0.0, 1.2246467991473532e-16, -1.0]
                             datatype: float64
                             shape: [3, 3]
-                        coordinates: !weldx!core/variable-0.1.0
+                        coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
                           name: coordinates
                           dimensions: [time, c]
                           dtype: <f8
@@ -262,17 +262,17 @@ examples:
                             - [295.0, 0.0, 2.0]
                             datatype: float64
                             shape: [2, 3]
-                    target_node: !weldx!core/graph/di_node-0.1.0
+                    target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                       name: tcp_wire
                       attributes:
                         data: {}
                       edges:
-                      - !weldx!core/graph/di_edge-0.1.0
+                      - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                         direction: bwd
                         attributes:
                           defined: true
-                          transformation: !weldx!core/transformations/local_coordinate_system-0.1.0
-                            coordinates: !weldx!core/variable-0.1.0
+                          transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
+                            coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
                               name: coordinates
                               dimensions: [c]
                               dtype: <f8
@@ -280,230 +280,230 @@ examples:
                                 data: [0.0, 0.0, -10.0]
                                 datatype: float64
                                 shape: [3]
-                        target_node: !weldx!core/graph/di_node-0.1.0
+                        target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                           name: tcp_contact
                           attributes:
                             data: {}
           subsystems: []
         equipment:
-        - &id008 !weldx!equipment/measurement_equipment-0.1.0
+        - &id008 !<asdf://weldx.bam.de/weldx/tags/equipment/measurement_equipment-0.1.0>
           name: HKS P1000-S3
           sources:
-          - &id003 !weldx!measurement/source-0.1.0
+          - &id003 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
             name: Current Sensor
-            output_signal: &id004 !weldx!measurement/signal-0.1.0
+            output_signal: &id004 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
               signal_type: analog
-              units: !weldx!unit/unit-0.1.0 volt
-            error: !weldx!measurement/error-0.1.0
-              deviation: !weldx!unit/quantity-0.1.0 {value: 0.1, units: !weldx!unit/unit-0.1.0 percent}
-          - &id011 !weldx!measurement/source-0.1.0
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt
+            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
+          - &id011 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
             name: Voltage Sensor
-            output_signal: &id012 !weldx!measurement/signal-0.1.0
+            output_signal: &id012 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
               signal_type: analog
-              units: !weldx!unit/unit-0.1.0 volt
-            error: !weldx!measurement/error-0.1.0
-              deviation: !weldx!unit/quantity-0.1.0 {value: 0.1, units: !weldx!unit/unit-0.1.0 percent}
+              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt
+            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
           transformations: []
-        - &id005 !weldx!equipment/measurement_equipment-0.1.0
+        - &id005 !<asdf://weldx.bam.de/weldx/tags/equipment/measurement_equipment-0.1.0>
           name: Beckhoff ELM3002-0000
           sources: []
           transformations:
-          - &id006 !weldx!measurement/signal_transformation-0.1.0
+          - &id006 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
             name: AD conversion current measurement
-            error: !weldx!measurement/error-0.1.0
-              deviation: !weldx!unit/quantity-0.1.0 {value: 0.01, units: !weldx!unit/unit-0.1.0 percent}
-            func: !weldx!core/mathematical_expression-0.1.0
+            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
+            func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
               expression: a*x + b
               parameters:
-                a: !weldx!unit/quantity-0.1.0 {value: 3276.8, units: !weldx!unit/unit-0.1.0 1
+                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1
                     / volt}
-                b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 dimensionless}
+                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> dimensionless}
             type_transformation: AD
-          - &id013 !weldx!measurement/signal_transformation-0.1.0
+          - &id013 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
             name: AD conversion voltage measurement
-            error: !weldx!measurement/error-0.1.0
-              deviation: !weldx!unit/quantity-0.1.0 {value: 0.01, units: !weldx!unit/unit-0.1.0 percent}
-            func: !weldx!core/mathematical_expression-0.1.0
+            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
+            func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
               expression: a*x + b
               parameters:
-                a: !weldx!unit/quantity-0.1.0 {value: 3276.8, units: !weldx!unit/unit-0.1.0 1
+                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1
                     / volt}
-                b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 dimensionless}
+                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> dimensionless}
             type_transformation: AD
         measurements:
-        - !weldx!measurement/measurement-0.1.0
+        - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
           name: welding current measurement
           data:
-          - &id007 !weldx!core/time_series-0.1.0
+          - &id007 !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
             &id001 values: &id002 !core/ndarray-1.0.0
               data: [300.0, 299.9999999999999, 299.99999999999983, 299.99999999999915, 299.9999999999996,
                 300.00000000000006]
               datatype: float64
               shape: [6]
-            time: !weldx!time/timedeltaindex-0.1.0 {start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
-              end: !weldx!time/timedelta-0.1.0 P0DT0H0M10S, freq: 2S, min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
-              max: !weldx!time/timedelta-0.1.0 P0DT0H0M10S}
-            units: !weldx!unit/unit-0.1.0 ampere
+            time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0> {start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S,
+              end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S, freq: 2S, min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S,
+              max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S}
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ampere
             shape: [6]
             interpolation: step
             *id001 : *id002
-          measurement_chain: !weldx!measurement/measurement_chain-0.1.0
+          measurement_chain: !<asdf://weldx.bam.de/weldx/tags/measurement/measurement_chain-0.1.0>
             name: welding current measurement chain
             data_source: *id003
-            graph: !weldx!core/graph/di_graph-0.1.0
-              root_node: !weldx!core/graph/di_node-0.1.0
+            graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
+              root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                 name: Current Sensor
                 attributes:
                   signal: *id004
                 edges:
-                - !weldx!core/graph/di_edge-0.1.0
+                - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                   direction: fwd
                   attributes:
                     equipment: *id005
                     transformation: *id006
-                  target_node: !weldx!core/graph/di_node-0.1.0
+                  target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                     name: AD conversion current measurement
                     attributes:
-                      signal: !weldx!measurement/signal-0.1.0
+                      signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                         signal_type: digital
-                        units: !weldx!unit/unit-0.1.0 dimensionless
+                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> dimensionless
                     edges:
-                    - !weldx!core/graph/di_edge-0.1.0
+                    - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                       direction: fwd
                       attributes:
-                        transformation: !weldx!measurement/signal_transformation-0.1.0
+                        transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
                           name: Calibration current measurement
-                          error: !weldx!measurement/error-0.1.0
+                          error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
                             deviation: 0.0
-                          func: !weldx!core/mathematical_expression-0.1.0
+                          func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                             expression: a*x + b
                             parameters:
-                              a: !weldx!unit/quantity-0.1.0 {value: 0.030517578125, units: !weldx!unit/unit-0.1.0 ampere}
-                              b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 ampere}
+                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ampere}
+                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ampere}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
-                      target_node: !weldx!core/graph/di_node-0.1.0
+                      target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                         name: Calibration current measurement
                         attributes:
-                          signal: !weldx!measurement/signal-0.1.0
+                          signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                             signal_type: digital
-                            units: !weldx!unit/unit-0.1.0 ampere
+                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ampere
                             data: *id007
             source_equipment: *id008
-        - !weldx!measurement/measurement-0.1.0
+        - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
           name: welding voltage measurement
           data:
-          - &id014 !weldx!core/time_series-0.1.0
+          - &id014 !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
             &id009 values: &id010 !core/ndarray-1.0.0
               data: [40.299500249940486, 40.29950024994045, 40.299500249940436, 40.29950024994042,
                 40.29950024994049, 40.299500249940564]
               datatype: float64
               shape: [6]
-            time: !weldx!time/timedeltaindex-0.1.0 {start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
-              end: !weldx!time/timedelta-0.1.0 P0DT0H0M10S, freq: 2S, min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
-              max: !weldx!time/timedelta-0.1.0 P0DT0H0M10S}
-            units: !weldx!unit/unit-0.1.0 volt
+            time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0> {start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S,
+              end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S, freq: 2S, min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S,
+              max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S}
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt
             shape: [6]
             interpolation: step
             *id009 : *id010
-          measurement_chain: !weldx!measurement/measurement_chain-0.1.0
+          measurement_chain: !<asdf://weldx.bam.de/weldx/tags/measurement/measurement_chain-0.1.0>
             name: welding voltage measurement chain
             data_source: *id011
-            graph: !weldx!core/graph/di_graph-0.1.0
-              root_node: !weldx!core/graph/di_node-0.1.0
+            graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
+              root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                 name: Voltage Sensor
                 attributes:
                   signal: *id012
                 edges:
-                - !weldx!core/graph/di_edge-0.1.0
+                - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                   direction: fwd
                   attributes:
                     equipment: *id005
                     transformation: *id013
-                  target_node: !weldx!core/graph/di_node-0.1.0
+                  target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                     name: AD conversion voltage measurement
                     attributes:
-                      signal: !weldx!measurement/signal-0.1.0
+                      signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                         signal_type: digital
-                        units: !weldx!unit/unit-0.1.0 dimensionless
+                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> dimensionless
                     edges:
-                    - !weldx!core/graph/di_edge-0.1.0
+                    - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
                       direction: fwd
                       attributes:
-                        transformation: !weldx!measurement/signal_transformation-0.1.0
+                        transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
                           name: Calibration voltage measurement
-                          error: !weldx!measurement/error-0.1.0
+                          error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
                             deviation: 0.0
-                          func: !weldx!core/mathematical_expression-0.1.0
+                          func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
                             expression: a*x + b
                             parameters:
-                              a: !weldx!unit/quantity-0.1.0 {value: 0.0030517578125, units: !weldx!unit/unit-0.1.0 volt}
-                              b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 volt}
+                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt}
+                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
-                      target_node: !weldx!core/graph/di_node-0.1.0
+                      target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
                         name: Calibration voltage measurement
                         attributes:
-                          signal: !weldx!measurement/signal-0.1.0
+                          signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
                             signal_type: digital
-                            units: !weldx!unit/unit-0.1.0 volt
+                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt
                             data: *id014
             source_equipment: *id008
         process:
-          shielding_gas: !weldx!aws/process/shielding_gas_for_procedure-0.1.0
+          shielding_gas: !<asdf://weldx.bam.de/weldx/tags/aws/process/shielding_gas_for_procedure-0.1.0>
             use_torch_shielding_gas: true
-            torch_shielding_gas: !weldx!aws/process/shielding_gas_type-0.1.0
+            torch_shielding_gas: !<asdf://weldx.bam.de/weldx/tags/aws/process/shielding_gas_type-0.1.0>
               gas_component:
-              - !weldx!aws/process/gas_component-0.1.0
+              - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
                 gas_chemical_name: argon
-                gas_percentage: !weldx!unit/quantity-0.1.0 {value: 82, units: !weldx!unit/unit-0.1.0 percent}
-              - !weldx!aws/process/gas_component-0.1.0
+                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
+              - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
                 gas_chemical_name: carbon dioxide
-                gas_percentage: !weldx!unit/quantity-0.1.0 {value: 18, units: !weldx!unit/unit-0.1.0 percent}
+                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> percent}
               common_name: SG
-            torch_shielding_gas_flowrate: !weldx!unit/quantity-0.1.0 {value: 20, units: !weldx!unit/unit-0.1.0 liter
+            torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> liter
                 / minute}
-          weld_speed: !weldx!core/time_series-0.1.0
-            units: !weldx!unit/unit-0.1.0 millimeter / second
+          weld_speed: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter / second
             value: 10
-          welding_process: !weldx!process/CLOOS/pulse-0.1.0
+          welding_process: !<asdf://weldx.bam.de/weldx/tags/process/CLOOS/pulse-0.1.0>
             base_process: pulse
             manufacturer: CLOOS
             meta: {modulation: UI}
             parameters:
-              base_current: !weldx!core/time_series-0.1.0
-                units: !weldx!unit/unit-0.1.0 ampere
+              base_current: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ampere
                 value: 60.0
-              pulse_duration: !weldx!core/time_series-0.1.0
-                units: !weldx!unit/unit-0.1.0 millisecond
+              pulse_duration: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millisecond
                 value: 5.0
-              pulse_frequency: !weldx!core/time_series-0.1.0
-                units: !weldx!unit/unit-0.1.0 hertz
+              pulse_frequency: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> hertz
                 value: 100.0
-              pulse_voltage: !weldx!core/time_series-0.1.0
-                units: !weldx!unit/unit-0.1.0 volt
+              pulse_voltage: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> volt
                 value: 40.0
-              wire_feedrate: !weldx!core/time_series-0.1.0
-                units: !weldx!unit/unit-0.1.0 meter / minute
+              wire_feedrate: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> meter / minute
                 value: 10.0
             power_source: Quinto
             tag: CLOOS/pulse
           welding_wire:
-            diameter: !weldx!unit/quantity-0.1.0 {value: 1.2, units: !weldx!unit/unit-0.1.0 millimeter}
-        reference_timestamp: !weldx!time/timestamp-0.1.0 2020-11-09T12:00:00
+            diameter: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter}
+        reference_timestamp: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> 2020-11-09T12:00:00
         welding_current: *id007
         welding_voltage: *id014
         workpiece:
           base_metal: {common_name: S355J2+N, standard: 'DIN EN 10225-2:2011'}
           geometry:
-            groove_shape: !weldx!groove/iso_9692_1_2013_12/VGroove-0.1.0
-              t: !weldx!unit/quantity-0.1.0 {value: 5, units: !weldx!unit/unit-0.1.0 millimeter}
-              alpha: !weldx!unit/quantity-0.1.0 {value: 50, units: !weldx!unit/unit-0.1.0 degree}
-              b: !weldx!unit/quantity-0.1.0 {value: 1, units: !weldx!unit/unit-0.1.0 millimeter}
-              c: !weldx!unit/quantity-0.1.0 {value: 1, units: !weldx!unit/unit-0.1.0 millimeter}
+            groove_shape: !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/VGroove-0.1.0>
+              t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter}
+              alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 50, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> degree}
+              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter}
+              c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter}
               code_number: ['1.3', '1.5']
-            seam_length: !weldx!unit/quantity-0.1.0 {value: 300, units: !weldx!unit/unit-0.1.0 millimeter}
+            seam_length: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 300, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> millimeter}
         wx_metadata: {welder: A.W. Elder}
 ...

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -167,17 +167,28 @@ examples:
     - A simple welding application
     - |
       !<tag:stsci.edu:asdf/core/asdf-1.1.0>
-        TCP: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
-          time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
+        asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+          name: asdf, version: 2.8.1}
+        history:
+          extensions:
+          - !core/extension_metadata-1.0.0
+            extension_class: asdf.extension.BuiltinExtension
+            software: !core/software-1.0.0 {name: asdf, version: 2.8.1}
+          - !core/extension_metadata-1.0.0
+            extension_class: weldx.asdf.extension.WeldxExtension
+            extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.0
+            software: !core/software-1.0.0 {name: weldx, version: 0.4.2.dev34+gf6e3c49.d20210820}
+        TCP: !weldx!core/transformations/local_coordinate_system-0.1.0
+          time: !weldx!time/timedeltaindex-0.1.0
             values: !core/ndarray-1.0.0
               data: [0, 29000000000]
               datatype: int64
               shape: [2]
-            start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-            end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
-            min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-            max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
-          orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
+            start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
+            end: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
+            min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
+            max: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
+          orientations: !weldx!core/variable-0.1.0
             name: orientations
             dimensions: [c, v]
             dtype: <f8
@@ -188,7 +199,7 @@ examples:
               - [0.0, 1.2246467991473532e-16, -1.0]
               datatype: float64
               shape: [3, 3]
-          coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
+          coordinates: !weldx!core/variable-0.1.0
             name: coordinates
             dimensions: [time, c]
             dtype: <f8
@@ -198,39 +209,39 @@ examples:
               - [295.0, 1.2246467991473533e-15, 12.0]
               datatype: float64
               shape: [2, 3]
-        coordinate_systems: !<asdf://weldx.bam.de/weldx/tags/core/transformations/coordinate_system_hierarchy-0.1.0>
+        coordinate_systems: !weldx!core/transformations/coordinate_system_hierarchy-0.1.0
           name: Coordinate system manager 0
-          graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
-            root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+          graph: !weldx!core/graph/di_graph-0.1.0
+            root_node: !weldx!core/graph/di_node-0.1.0
               name: base
               attributes:
                 data: {}
               edges:
-              - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+              - !weldx!core/graph/di_edge-0.1.0
                 direction: bwd
                 attributes:
                   defined: true
-                  transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0> {}
-                target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                  transformation: !weldx!core/transformations/local_coordinate_system-0.1.0 {}
+                target_node: !weldx!core/graph/di_node-0.1.0
                   name: workpiece
                   attributes:
                     data: {}
                   edges:
-                  - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                  - !weldx!core/graph/di_edge-0.1.0
                     direction: bwd
                     attributes:
                       defined: true
-                      transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
-                        time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
+                      transformation: !weldx!core/transformations/local_coordinate_system-0.1.0
+                        time: !weldx!time/timedeltaindex-0.1.0
                           values: !core/ndarray-1.0.0
                             data: [0, 29000000000]
                             datatype: int64
                             shape: [2]
-                          start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-                          end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
-                          min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-                          max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M29S
-                        orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
+                          start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
+                          end: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
+                          min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S
+                          max: !weldx!time/timedelta-0.1.0 P0DT0H0M29S
+                        orientations: !weldx!core/variable-0.1.0
                           name: orientations
                           dimensions: [c, v]
                           dtype: <f8
@@ -241,7 +252,7 @@ examples:
                             - [0.0, 1.2246467991473532e-16, -1.0]
                             datatype: float64
                             shape: [3, 3]
-                        coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
+                        coordinates: !weldx!core/variable-0.1.0
                           name: coordinates
                           dimensions: [time, c]
                           dtype: <f8
@@ -251,17 +262,17 @@ examples:
                             - [295.0, 0.0, 2.0]
                             datatype: float64
                             shape: [2, 3]
-                    target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                    target_node: !weldx!core/graph/di_node-0.1.0
                       name: tcp_wire
                       attributes:
                         data: {}
                       edges:
-                      - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                      - !weldx!core/graph/di_edge-0.1.0
                         direction: bwd
                         attributes:
                           defined: true
-                          transformation: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
-                            coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
+                          transformation: !weldx!core/transformations/local_coordinate_system-0.1.0
+                            coordinates: !weldx!core/variable-0.1.0
                               name: coordinates
                               dimensions: [c]
                               dtype: <f8
@@ -269,233 +280,230 @@ examples:
                                 data: [0.0, 0.0, -10.0]
                                 datatype: float64
                                 shape: [3]
-                        target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                        target_node: !weldx!core/graph/di_node-0.1.0
                           name: tcp_contact
                           attributes:
                             data: {}
           subsystems: []
         equipment:
-        - &id008 !<asdf://weldx.bam.de/weldx/tags/equipment/measurement_equipment-0.1.0>
+        - &id008 !weldx!equipment/measurement_equipment-0.1.0
           name: HKS P1000-S3
           sources:
-          - &id003 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
+          - &id003 !weldx!measurement/source-0.1.0
             name: Current Sensor
-            output_signal: &id004 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+            output_signal: &id004 !weldx!measurement/signal-0.1.0
               signal_type: analog
-              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
-            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
-          - &id011 !<asdf://weldx.bam.de/weldx/tags/measurement/source-0.1.0>
+              units: !weldx!unit/unit-0.1.0 volt
+            error: !weldx!measurement/error-0.1.0
+              deviation: !weldx!unit/quantity-0.1.0 {value: 0.1, units: !weldx!unit/unit-0.1.0 percent}
+          - &id011 !weldx!measurement/source-0.1.0
             name: Voltage Sensor
-            output_signal: &id012 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+            output_signal: &id012 !weldx!measurement/signal-0.1.0
               signal_type: analog
-              units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
-            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+              units: !weldx!unit/unit-0.1.0 volt
+            error: !weldx!measurement/error-0.1.0
+              deviation: !weldx!unit/quantity-0.1.0 {value: 0.1, units: !weldx!unit/unit-0.1.0 percent}
           transformations: []
-        - &id005 !<asdf://weldx.bam.de/weldx/tags/equipment/measurement_equipment-0.1.0>
+        - &id005 !weldx!equipment/measurement_equipment-0.1.0
           name: Beckhoff ELM3002-0000
           sources: []
           transformations:
-          - &id006 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
+          - &id006 !weldx!measurement/signal_transformation-0.1.0
             name: AD conversion current measurement
-            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
-            func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
+            error: !weldx!measurement/error-0.1.0
+              deviation: !weldx!unit/quantity-0.1.0 {value: 0.01, units: !weldx!unit/unit-0.1.0 percent}
+            func: !weldx!core/mathematical_expression-0.1.0
               expression: a*x + b
               parameters:
-                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
-                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
+                a: !weldx!unit/quantity-0.1.0 {value: 3276.8, units: !weldx!unit/unit-0.1.0 1
+                    / volt}
+                b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 dimensionless}
             type_transformation: AD
-          - &id013 !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
+          - &id013 !weldx!measurement/signal_transformation-0.1.0
             name: AD conversion voltage measurement
-            error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
-              deviation: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.01, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
-            func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
+            error: !weldx!measurement/error-0.1.0
+              deviation: !weldx!unit/quantity-0.1.0 {value: 0.01, units: !weldx!unit/unit-0.1.0 percent}
+            func: !weldx!core/mathematical_expression-0.1.0
               expression: a*x + b
               parameters:
-                a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 3276.8, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> 1 / volt}
-                b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''}
+                a: !weldx!unit/quantity-0.1.0 {value: 3276.8, units: !weldx!unit/unit-0.1.0 1
+                    / volt}
+                b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 dimensionless}
             type_transformation: AD
         measurements:
-        - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
+        - !weldx!measurement/measurement-0.1.0
           name: welding current measurement
           data:
-          - &id007 !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+          - &id007 !weldx!core/time_series-0.1.0
             &id001 values: &id002 !core/ndarray-1.0.0
               data: [300.0, 299.9999999999999, 299.99999999999983, 299.99999999999915, 299.9999999999996,
                 300.00000000000006]
               datatype: float64
               shape: [6]
-            time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
-              start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-              end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S
-              freq: 2S
-              min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-              max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S
-            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
+            time: !weldx!time/timedeltaindex-0.1.0 {start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
+              end: !weldx!time/timedelta-0.1.0 P0DT0H0M10S, freq: 2S, min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
+              max: !weldx!time/timedelta-0.1.0 P0DT0H0M10S}
+            units: !weldx!unit/unit-0.1.0 ampere
             shape: [6]
             interpolation: step
             *id001 : *id002
-          measurement_chain: !<asdf://weldx.bam.de/weldx/tags/measurement/measurement_chain-0.1.0>
+          measurement_chain: !weldx!measurement/measurement_chain-0.1.0
             name: welding current measurement chain
             data_source: *id003
-            graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
-              root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+            graph: !weldx!core/graph/di_graph-0.1.0
+              root_node: !weldx!core/graph/di_node-0.1.0
                 name: Current Sensor
                 attributes:
                   signal: *id004
                 edges:
-                - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                - !weldx!core/graph/di_edge-0.1.0
                   direction: fwd
                   attributes:
                     equipment: *id005
                     transformation: *id006
-                  target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                  target_node: !weldx!core/graph/di_node-0.1.0
                     name: AD conversion current measurement
                     attributes:
-                      signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+                      signal: !weldx!measurement/signal-0.1.0
                         signal_type: digital
-                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''
+                        units: !weldx!unit/unit-0.1.0 dimensionless
                     edges:
-                    - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                    - !weldx!core/graph/di_edge-0.1.0
                       direction: fwd
                       attributes:
-                        transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
+                        transformation: !weldx!measurement/signal_transformation-0.1.0
                           name: Calibration current measurement
-                          error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+                          error: !weldx!measurement/error-0.1.0
                             deviation: 0.0
-                          func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
+                          func: !weldx!core/mathematical_expression-0.1.0
                             expression: a*x + b
                             parameters:
-                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
-                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A}
+                              a: !weldx!unit/quantity-0.1.0 {value: 0.030517578125, units: !weldx!unit/unit-0.1.0 ampere}
+                              b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 ampere}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
-                      target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                      target_node: !weldx!core/graph/di_node-0.1.0
                         name: Calibration current measurement
                         attributes:
-                          signal: &id015 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+                          signal: !weldx!measurement/signal-0.1.0
                             signal_type: digital
-                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
+                            units: !weldx!unit/unit-0.1.0 ampere
                             data: *id007
             source_equipment: *id008
-        - !<asdf://weldx.bam.de/weldx/tags/measurement/measurement-0.1.0>
+        - !weldx!measurement/measurement-0.1.0
           name: welding voltage measurement
           data:
-          - &id014 !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
+          - &id014 !weldx!core/time_series-0.1.0
             &id009 values: &id010 !core/ndarray-1.0.0
               data: [40.299500249940486, 40.29950024994045, 40.299500249940436, 40.29950024994042,
                 40.29950024994049, 40.299500249940564]
               datatype: float64
               shape: [6]
-            time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
-              start: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-              end: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S
-              freq: 2S
-              min: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M0S
-              max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S
-            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
+            time: !weldx!time/timedeltaindex-0.1.0 {start: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
+              end: !weldx!time/timedelta-0.1.0 P0DT0H0M10S, freq: 2S, min: !weldx!time/timedelta-0.1.0 P0DT0H0M0S,
+              max: !weldx!time/timedelta-0.1.0 P0DT0H0M10S}
+            units: !weldx!unit/unit-0.1.0 volt
             shape: [6]
             interpolation: step
             *id009 : *id010
-          measurement_chain: !<asdf://weldx.bam.de/weldx/tags/measurement/measurement_chain-0.1.0>
+          measurement_chain: !weldx!measurement/measurement_chain-0.1.0
             name: welding voltage measurement chain
             data_source: *id011
-            graph: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.0>
-              root_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+            graph: !weldx!core/graph/di_graph-0.1.0
+              root_node: !weldx!core/graph/di_node-0.1.0
                 name: Voltage Sensor
                 attributes:
                   signal: *id012
                 edges:
-                - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                - !weldx!core/graph/di_edge-0.1.0
                   direction: fwd
                   attributes:
                     equipment: *id005
                     transformation: *id013
-                  target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                  target_node: !weldx!core/graph/di_node-0.1.0
                     name: AD conversion voltage measurement
                     attributes:
-                      signal: !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+                      signal: !weldx!measurement/signal-0.1.0
                         signal_type: digital
-                        units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ''
+                        units: !weldx!unit/unit-0.1.0 dimensionless
                     edges:
-                    - !<asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.0>
+                    - !weldx!core/graph/di_edge-0.1.0
                       direction: fwd
                       attributes:
-                        transformation: !<asdf://weldx.bam.de/weldx/tags/measurement/signal_transformation-0.1.0>
+                        transformation: !weldx!measurement/signal_transformation-0.1.0
                           name: Calibration voltage measurement
-                          error: !<asdf://weldx.bam.de/weldx/tags/measurement/error-0.1.0>
+                          error: !weldx!measurement/error-0.1.0
                             deviation: 0.0
-                          func: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
+                          func: !weldx!core/mathematical_expression-0.1.0
                             expression: a*x + b
                             parameters:
-                              a: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0030517578125, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
-                              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V}
+                              a: !weldx!unit/quantity-0.1.0 {value: 0.0030517578125, units: !weldx!unit/unit-0.1.0 volt}
+                              b: !weldx!unit/quantity-0.1.0 {value: 0.0, units: !weldx!unit/unit-0.1.0 volt}
                           wx_metadata:
                             software: !core/software-1.0.0 {name: Beckhoff TwinCAT ScopeView,
                               version: 3.4.3143}
-                      target_node: !<asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.0>
+                      target_node: !weldx!core/graph/di_node-0.1.0
                         name: Calibration voltage measurement
                         attributes:
-                          signal: &id016 !<asdf://weldx.bam.de/weldx/tags/measurement/signal-0.1.0>
+                          signal: !weldx!measurement/signal-0.1.0
                             signal_type: digital
-                            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
+                            units: !weldx!unit/unit-0.1.0 volt
                             data: *id014
             source_equipment: *id008
         process:
-          shielding_gas: !<asdf://weldx.bam.de/weldx/tags/aws/process/shielding_gas_for_procedure-0.1.0>
+          shielding_gas: !weldx!aws/process/shielding_gas_for_procedure-0.1.0
             use_torch_shielding_gas: true
-            torch_shielding_gas: !<asdf://weldx.bam.de/weldx/tags/aws/process/shielding_gas_type-0.1.0>
+            torch_shielding_gas: !weldx!aws/process/shielding_gas_type-0.1.0
               gas_component:
-              - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
+              - !weldx!aws/process/gas_component-0.1.0
                 gas_chemical_name: argon
-                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 82, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
-              - !<asdf://weldx.bam.de/weldx/tags/aws/process/gas_component-0.1.0>
+                gas_percentage: !weldx!unit/quantity-0.1.0 {value: 82, units: !weldx!unit/unit-0.1.0 percent}
+              - !weldx!aws/process/gas_component-0.1.0
                 gas_chemical_name: carbon dioxide
-                gas_percentage: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 18, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> '%'}
+                gas_percentage: !weldx!unit/quantity-0.1.0 {value: 18, units: !weldx!unit/unit-0.1.0 percent}
               common_name: SG
-            torch_shielding_gas_flowrate: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 20, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> l / min}
-          weld_speed: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-            units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm / s
+            torch_shielding_gas_flowrate: !weldx!unit/quantity-0.1.0 {value: 20, units: !weldx!unit/unit-0.1.0 liter
+                / minute}
+          weld_speed: !weldx!core/time_series-0.1.0
+            units: !weldx!unit/unit-0.1.0 millimeter / second
             value: 10
-          welding_process: !<asdf://weldx.bam.de/weldx/tags/process/CLOOS/pulse-0.1.0>
+          welding_process: !weldx!process/CLOOS/pulse-0.1.0
             base_process: pulse
             manufacturer: CLOOS
             meta: {modulation: UI}
             parameters:
-              base_current: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> A
+              base_current: !weldx!core/time_series-0.1.0
+                units: !weldx!unit/unit-0.1.0 ampere
                 value: 60.0
-              pulse_duration: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> ms
+              pulse_duration: !weldx!core/time_series-0.1.0
+                units: !weldx!unit/unit-0.1.0 millisecond
                 value: 5.0
-              pulse_frequency: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> Hz
+              pulse_frequency: !weldx!core/time_series-0.1.0
+                units: !weldx!unit/unit-0.1.0 hertz
                 value: 100.0
-              pulse_voltage: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> V
+              pulse_voltage: !weldx!core/time_series-0.1.0
+                units: !weldx!unit/unit-0.1.0 volt
                 value: 40.0
-              wire_feedrate: !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
-                units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm / min
+              wire_feedrate: !weldx!core/time_series-0.1.0
+                units: !weldx!unit/unit-0.1.0 meter / minute
                 value: 10.0
             power_source: Quinto
             tag: CLOOS/pulse
           welding_wire:
-            diameter: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1.2, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-        reference_timestamp: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> '2020-11-09T12:00:00'
-        welding_current: *id015
-        welding_voltage: *id016
+            diameter: !weldx!unit/quantity-0.1.0 {value: 1.2, units: !weldx!unit/unit-0.1.0 millimeter}
+        reference_timestamp: !weldx!time/timestamp-0.1.0 2020-11-09T12:00:00
+        welding_current: *id007
+        welding_voltage: *id014
         workpiece:
           base_metal: {common_name: S355J2+N, standard: 'DIN EN 10225-2:2011'}
           geometry:
-            groove_shape: !<asdf://weldx.bam.de/weldx/tags/groove/iso_9692_1_2013_12/VGroove-0.1.0>
-              t: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 5, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-              alpha: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 50, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> deg}
-              b: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
-              c: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 1, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+            groove_shape: !weldx!groove/iso_9692_1_2013_12/VGroove-0.1.0
+              t: !weldx!unit/quantity-0.1.0 {value: 5, units: !weldx!unit/unit-0.1.0 millimeter}
+              alpha: !weldx!unit/quantity-0.1.0 {value: 50, units: !weldx!unit/unit-0.1.0 degree}
+              b: !weldx!unit/quantity-0.1.0 {value: 1, units: !weldx!unit/unit-0.1.0 millimeter}
+              c: !weldx!unit/quantity-0.1.0 {value: 1, units: !weldx!unit/unit-0.1.0 millimeter}
               code_number: ['1.3', '1.5']
-            seam_length: !<asdf://weldx.bam.de/weldx/tags/unit/quantity-0.1.0> {value: 300, units: !<asdf://weldx.bam.de/weldx/tags/unit/unit-0.1.0> mm}
+            seam_length: !weldx!unit/quantity-0.1.0 {value: 300, units: !weldx!unit/unit-0.1.0 millimeter}
         wx_metadata: {welder: A.W. Elder}
 ...

--- a/weldx/tests/test_utility.py
+++ b/weldx/tests/test_utility.py
@@ -507,7 +507,7 @@ class TestWeldxExampleCompareNested(unittest.TestCase):
         assert not ut.compare_nested(self.a, self.b)
 
     def test_measurements_modified(self):  # noqa: D102
-        self.b["welding_current"].data.data[-1] = Q_(500, "A")
+        self.b["welding_current"].data[-1] = Q_(500, "A")
         assert not ut.compare_nested(self.a, self.b)
 
     def test_equip_modified(self):  # noqa: D102


### PR DESCRIPTION
## Changes

Update the single-pass weld schema to use a `TimeSeries` instead of a `Signal` for `welding_current` and `welding_voltage`

## Related Issues

See #559 

## Checks

- [x] updated CHANGELOG.rst
- [x] ~~updated tests~~
- [x] updated doc/
- [x] ~~update example/tutorial notebooks~~
- [x] ~~update manifest file~~
