### PR TITLE
change docs artifact condition

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: set notebook execution
         if: (github.event_name == 'workflow_dispatch')
-        run: echo "nbsphinx_execute=${{ github.event.inputs.nbsphinx_execute }}"" >> $GITHUB_ENV
+        run: echo "nbsphinx_execute=${{ github.event.inputs.nbsphinx_execute }}" >> $GITHUB_ENV
 
       - name: Build docs
         shell: bash -l {0}


### PR DESCRIPTION
## Changes

artifacts get created for runs on master,tags,releases,PR (ready for review) and manual workflow runs
for manual workflow runs one can set the desired notebook execution setting (e.g. `'never'` to skip running tutorials, should save 2-3 minutes), default is `'always'` (also for all automatically triggered runs)

go here to dispatch workflow manually (select branch): https://github.com/BAMWelDX/weldx/actions/workflows/docs.yml
same for forks: https://github.com/CagtayFabry/weldx/actions/workflows/docs.yml
