### PR TITLE
run build on 'published' instead of 'created' release events

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -14,7 +14,6 @@ on:
   release:
     types:
       - published
-      - created
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -13,6 +13,7 @@ on:
       - '!.github/workflows/build.yml'
   release:
     types:
+      - published
       - created
   schedule:
     - cron: '0 6 * * 1'
@@ -25,7 +26,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.ref == 'refs/heads/master') ||
       startsWith(github.ref, 'refs/tags/') ||
-      (github.event_name == 'release' && github.event.action == 'created')
+      (github.event_name == 'release')
     name: conda build
     runs-on: ubuntu-latest
     steps:
@@ -70,7 +71,7 @@ jobs:
       (github.event.pull_request.draft == false) ||
       (github.event_name == 'workflow_dispatch') ||
       startsWith(github.ref, 'refs/tags/') ||
-      (github.event_name == 'release' && github.event.action == 'created')
+      (github.event_name == 'release')
     name: pypi build
     runs-on: ubuntu-latest
     steps:
@@ -124,12 +125,12 @@ jobs:
           echo "pypi_token=${{ secrets.TESTPYPI_UPLOAD }}" >> $GITHUB_ENV
 
       - name: set pypi main repo for release
-        if: github.event_name == 'release' && github.event.action == 'created'
+        if: github.event_name == 'release'
         run: |
           echo "pypi_repo=pypi" >> $GITHUB_ENV
           echo "pypi_token=${{ secrets.PYPI_UPLOAD }}" >> $GITHUB_ENV
 
       - name: pypi release
-        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'release' && github.event.action == 'created')
+        if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'release')
         run: |
           python -m twine upload --repository $pypi_repo dist/* -u __token__ -p $pypi_token


### PR DESCRIPTION
the `created` release event is not triggered when publishing a saved draft release so this should do what we actually want

