### PR TITLE
Check time coords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,15 @@ changes
    from the dictionary interface. To access these, there are separate
    properties `[#625] <https://github.com/BAMWeldX/weldx/pull/625>`__.
 
+-  Allow handling of ``time`` values as singular coordinates without
+   dimensions in some classes `[#635]
+   <https://github.com/BAMWeldX/weldx/pull/635>`__.
+
 fixes
 =====
+
+-  Fix wrong dimension order being passed through in `SpatialData`
+   `[#635] <https://github.com/BAMWeldX/weldx/pull/635>`__.
 
 documentation
 =============

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2538,6 +2538,9 @@ class SpatialData:
                 add_dims=["n"],
             )
 
+        # make sure we have correct dimension order
+        self.coordinates = self.coordinates.transpose(..., "n", "c")
+
         if self.triangles is not None:
             if not isinstance(self.triangles, np.ndarray):
                 self.triangles = np.array(self.triangles, dtype="uint")
@@ -2801,7 +2804,7 @@ class SpatialData:
     @property
     def is_time_dependent(self) -> bool:
         """Return `True` if the coordinates are time dependent."""
-        return "time" in self.coordinates.coords
+        return "time" in self.coordinates.dims
 
     @property
     def additional_dims(self) -> List[str]:

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2801,7 +2801,7 @@ class SpatialData:
     @property
     def is_time_dependent(self) -> bool:
         """Return `True` if the coordinates are time dependent."""
-        return "time" in self.coordinates.dims
+        return "time" in self.coordinates.coords
 
     @property
     def additional_dims(self) -> List[str]:

--- a/weldx/tags/core/transformations/local_coordinate_system.py
+++ b/weldx/tags/core/transformations/local_coordinate_system.py
@@ -40,7 +40,7 @@ class LocalCoordinateSystemConverter(WeldxConverter):
             #         ctx.set_array_storage(coordinates.data, "inline")
             tree["coordinates"] = coordinates
 
-        if "time" in obj.dataset.dims:
+        if "time" in obj.dataset.coords:
             tree["time"] = obj.time.as_timedelta_index()
 
         if obj.reference_time is not None:

--- a/weldx/tests/transformations/test_cs_manager.py
+++ b/weldx/tests/transformations/test_cs_manager.py
@@ -2614,6 +2614,7 @@ def test_issue_289_interp_outside_time_range(
     exp_orient = WXRotation.from_euler("x", exp_angle, degrees=True).as_matrix()
     exp_coords = [0, 0, 0] if time_dep_coords and all_less else [1, 1, 1]
 
+    assert cs_br.is_time_dependent is False
     assert cs_br.time is None
     assert cs_br.coordinates.values.shape == (3,)
     assert cs_br.orientation.values.shape == (3, 3)

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -498,11 +498,7 @@ def test_issue_289_interp_outside_time_range(
     exp_coords = [0, 0, 0] if time_dep_coords and all_less else [1, 1, 1]
 
     assert lcs_interp.is_time_dependent is False
-    if time_dep_coords or time_dep_orient:
-        if all_less:
-            assert lcs_interp.time.equals(Time(time[0]))
-        else:
-            assert lcs_interp.time.equals(Time(time[-1]))
+    assert lcs_interp.time is None
     assert lcs_interp.coordinates.values.shape == (3,)
     assert lcs_interp.orientation.values.shape == (3, 3)
     assert np.all(lcs_interp.coordinates.data == exp_coords)

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -497,7 +497,12 @@ def test_issue_289_interp_outside_time_range(
     exp_orient = WXRotation.from_euler("x", exp_angle, degrees=True).as_matrix()
     exp_coords = [0, 0, 0] if time_dep_coords and all_less else [1, 1, 1]
 
-    assert lcs_interp.time is None
+    assert lcs_interp.is_time_dependent is False
+    if time_dep_coords or time_dep_orient:
+        if all_less:
+            assert lcs_interp.time.equals(Time(time[0]))
+        else:
+            assert lcs_interp.time.equals(Time(time[-1]))
     assert lcs_interp.coordinates.values.shape == (3,)
     assert lcs_interp.orientation.values.shape == (3, 3)
     assert np.all(lcs_interp.coordinates.data == exp_coords)
@@ -518,7 +523,7 @@ def test_interp_time_discrete_single_time():
     exp_orient = WXRotation.from_euler("x", 90, degrees=True).as_matrix()
 
     lcs_interp = lcs.interp_time("2s")
-    assert lcs_interp.time is None
+    assert lcs_interp.time.equals(Time("2s"))
     assert lcs_interp.coordinates.values.shape == (3,)
     assert lcs_interp.orientation.values.shape == (3, 3)
     assert np.all(lcs_interp.coordinates.data == exp_coords)

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -519,6 +519,7 @@ def test_interp_time_discrete_single_time():
     exp_orient = WXRotation.from_euler("x", 90, degrees=True).as_matrix()
 
     lcs_interp = lcs.interp_time("2s")
+    assert lcs_interp.is_time_dependent is False
     assert lcs_interp.time.equals(Time("2s"))
     assert lcs_interp.coordinates.values.shape == (3,)
     assert lcs_interp.orientation.values.shape == (3, 3)

--- a/weldx/time.py
+++ b/weldx/time.py
@@ -668,7 +668,10 @@ class Time:
         if "time" in time.coords:
             time = time.time
         time_ref = time.weldx.time_ref
-        time_index = pd.Index(time.values)
+        if time.shape:
+            time_index = pd.Index(time.values)
+        else:
+            time_index = pd.Index([time.values])
         if time_ref is not None:
             time_index = time_index + time_ref
         return time_index

--- a/weldx/transformations/cs_manager.py
+++ b/weldx/transformations/cs_manager.py
@@ -1697,7 +1697,7 @@ class CoordinateSystemManager:
         if not isinstance(data, xr.DataArray):
             data = xr.DataArray(data, dims=["n", "c"], coords={"c": ["x", "y", "z"]})
 
-        time = data.time if "time" in data.dims else None
+        time = data.time if "time" in data.coords else None
         lcs = self.get_cs(
             source_coordinate_system_name, target_coordinate_system_name, time=time
         )

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -78,8 +78,10 @@ class LocalCoordinateSystem(TimeDependent):
         # warn about dropped time data
         if (
             time is not None
-            and "time" not in orientation.dims
-            and (isinstance(coordinates, TimeSeries) or "time" not in coordinates.dims)
+            and "time" not in orientation.coords
+            and (
+                isinstance(coordinates, TimeSeries) or "time" not in coordinates.coords
+            )
         ):
             warnings.warn(
                 "Provided time is dropped because of the given coordinates and "
@@ -380,8 +382,8 @@ class LocalCoordinateSystem(TimeDependent):
         """Unify time axis of orientation and coordinates if both are DataArrays."""
         if (
             not isinstance(coordinates, TimeSeries)
-            and ("time" in orientation.dims)
-            and ("time" in coordinates.dims)
+            and ("time" in orientation.coords)
+            and ("time" in coordinates.coords)
             and (not np.all(orientation.time.data == coordinates.time.data))
         ):
             time_union = Time.union([orientation.time, coordinates.time])
@@ -593,7 +595,7 @@ class LocalCoordinateSystem(TimeDependent):
             Time-like data array representing the time union of the LCS
 
         """
-        if "time" in self._dataset.dims:
+        if "time" in self._dataset.coords:
             return Time(self._dataset.time, self.reference_time)
         return None
 

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -78,6 +78,7 @@ class LocalCoordinateSystem(TimeDependent):
         # warn about dropped time data
         if (
             time is not None
+            and len(Time(time)) > 1
             and "time" not in orientation.dims
             and (isinstance(coordinates, TimeSeries) or "time" not in coordinates.dims)
         ):

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -667,9 +667,9 @@ class LocalCoordinateSystem(TimeDependent):
         if "time" not in self.orientation.dims:  # don't interpolate static
             return self.orientation
         if time.max() <= self.time.min():  # only use edge timestamp
-            return self.orientation.isel(time=0)
+            return self.orientation.isel(time=0).data
         if time.min() >= self.time.max():  # only use edge timestamp
-            return self.orientation.isel(time=-1)
+            return self.orientation.isel(time=-1).data
         # full interpolation with overlapping times
         return ut.xr_interp_orientation_in_time(self.orientation, time)
 
@@ -686,9 +686,9 @@ class LocalCoordinateSystem(TimeDependent):
         if "time" not in self.coordinates.dims:  # don't interpolate static
             return self.coordinates
         if time.max() <= self.time.min():  # only use edge timestamp
-            return self.coordinates.isel(time=0)
+            return self.coordinates.isel(time=0).data
         if time.min() >= self.time.max():  # only use edge timestamp
-            return self.coordinates.isel(time=-1)
+            return self.coordinates.isel(time=-1).data
         # full interpolation with overlapping times
         return ut.xr_interp_coordinates_in_time(self.coordinates, time)
 

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -78,10 +78,8 @@ class LocalCoordinateSystem(TimeDependent):
         # warn about dropped time data
         if (
             time is not None
-            and "time" not in orientation.coords
-            and (
-                isinstance(coordinates, TimeSeries) or "time" not in coordinates.coords
-            )
+            and "time" not in orientation.dims
+            and (isinstance(coordinates, TimeSeries) or "time" not in coordinates.dims)
         ):
             warnings.warn(
                 "Provided time is dropped because of the given coordinates and "
@@ -382,8 +380,8 @@ class LocalCoordinateSystem(TimeDependent):
         """Unify time axis of orientation and coordinates if both are DataArrays."""
         if (
             not isinstance(coordinates, TimeSeries)
-            and ("time" in orientation.coords)
-            and ("time" in coordinates.coords)
+            and ("time" in orientation.dims)
+            and ("time" in coordinates.dims)
             and (not np.all(orientation.time.data == coordinates.time.data))
         ):
             time_union = Time.union([orientation.time, coordinates.time])

--- a/weldx/transformations/local_cs.py
+++ b/weldx/transformations/local_cs.py
@@ -548,7 +548,7 @@ class LocalCoordinateSystem(TimeDependent):
             `True` if the coordinate system is time dependent, `False` otherwise.
 
         """
-        return self.time is not None or self._coord_ts is not None
+        return self._coord_ts is not None or ("time" in self._dataset.dims)
 
     @property
     def has_timeseries(self) -> bool:
@@ -667,9 +667,9 @@ class LocalCoordinateSystem(TimeDependent):
         if "time" not in self.orientation.dims:  # don't interpolate static
             return self.orientation
         if time.max() <= self.time.min():  # only use edge timestamp
-            return self.orientation.values[0]
+            return self.orientation.isel(time=0)
         if time.min() >= self.time.max():  # only use edge timestamp
-            return self.orientation.values[-1]
+            return self.orientation.isel(time=-1)
         # full interpolation with overlapping times
         return ut.xr_interp_orientation_in_time(self.orientation, time)
 
@@ -686,9 +686,9 @@ class LocalCoordinateSystem(TimeDependent):
         if "time" not in self.coordinates.dims:  # don't interpolate static
             return self.coordinates
         if time.max() <= self.time.min():  # only use edge timestamp
-            return self.coordinates[0]
+            return self.coordinates.isel(time=0)
         if time.min() >= self.time.max():  # only use edge timestamp
-            return self.coordinates[-1]
+            return self.coordinates.isel(time=-1)
         # full interpolation with overlapping times
         return ut.xr_interp_coordinates_in_time(self.coordinates, time)
 

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -620,7 +620,7 @@ def xr_interp_orientation_in_time(
         Interpolated data
 
     """
-    if "time" not in da.dims:
+    if "time" not in da.coords:
         return da
     if len(da.time) == 1:  # remove "time dimension" for static case
         return da.isel({"time": 0})
@@ -677,7 +677,7 @@ def xr_interp_coordinates_in_time(
         Interpolated data
 
     """
-    if "time" not in da.dims:
+    if "time" not in da.coords:
         return da
 
     times = Time(times).as_pandas_index()
@@ -734,7 +734,7 @@ class WeldxAccessor:
     def time_ref_restore(self) -> xr.DataArray:
         """Convert DatetimeIndex back to TimedeltaIndex + reference Timestamp."""
         da = self._obj.copy()
-        if "time" not in da.dims:
+        if "time" not in da.coords:
             return da
 
         if is_datetime64_dtype(da.time):
@@ -757,7 +757,7 @@ class WeldxAccessor:
     def time_ref(self) -> Union[pd.Timestamp, None]:
         """Get the time_ref value or `None` if not set."""
         da = self._obj
-        if "time" in da.dims and "time_ref" in da.time.attrs:
+        if "time" in da.coords and "time_ref" in da.time.attrs:
             return da.time.attrs["time_ref"]
 
         return None

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -620,10 +620,10 @@ def xr_interp_orientation_in_time(
         Interpolated data
 
     """
-    if "time" not in da.coords:
+    if "time" not in da.dims:
         return da
-    # if len(da.time) == 1:  # remove "time dimension" for static case
-    #     return da.isel({"time": 0})
+    if len(da.time) == 1:  # remove "time dimension" for static case
+        return da.isel({"time": 0})
 
     time = Time(time).as_pandas_index()
     time_da = Time(da).as_pandas_index()

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -622,8 +622,8 @@ def xr_interp_orientation_in_time(
     """
     if "time" not in da.coords:
         return da
-    if len(da.time) == 1:  # remove "time dimension" for static case
-        return da.isel({"time": 0})
+    # if len(da.time) == 1:  # remove "time dimension" for static case
+    #     return da.isel({"time": 0})
 
     time = Time(time).as_pandas_index()
     time_da = Time(da).as_pandas_index()

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -677,7 +677,7 @@ def xr_interp_coordinates_in_time(
         Interpolated data
 
     """
-    if "time" not in da.coords:
+    if "time" not in da.dims:  # not time dependent
         return da
 
     times = Time(times).as_pandas_index()


### PR DESCRIPTION
## Changes

- check for `time` in xarray coordinates instead of dimensions in some cases

In cases where we access the `time` coordinate value I think it makes sense to check for time in the coordinates instead of the array dimensions. If time is a dimension without coordinates we would only get integer values which would be error prone.

In contrast if we actually want to check if an object is *time_dependent* (changing in time) we should look for time in the dimensions


However so far it is a bit inconsistent with single timestamps outside of the definition range:
```python
from weldx import LocalCoordinateSystem as LCS

lcs = LCS(coordinates=[[0,0,0],[1,0,0]],time=["0s","3s"])
lcs.interp_time("2s")
#> <LocalCoordinateSystem>
#> Dimensions:      (c: 3, v: 3)
#> Coordinates:
#>   * c            (c) <U1 'x' 'y' 'z'
#>   * v            (v) int32 0 1 2
#>     time         timedelta64[ns] 00:00:02
#> Data variables:
#>     orientation  (v, c) float64 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0
#>     coordinates  (c) float64 0.6667 0.0 0.0

lcs.interp_time("4s")
#> <LocalCoordinateSystem>
#> Dimensions:      (c: 3, v: 3)
#> Coordinates:
#>   * c            (c) <U1 'x' 'y' 'z'
#>   * v            (v) int32 0 1 2
#> Data variables:
#>     orientation  (v, c) float64 1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0
#>     coordinates  (c) float64 1.0 0.0 0.0
```

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
