### PR TITLE
[pre-commit] added clean notebook output hook

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -34,11 +34,3 @@ jobs:
       - name: run mypy
         run: |
           mypy --install-types --non-interactive .
-
-  check-notebooks:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Check notebooks
-        uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,9 @@ repos:
     hooks:
       - id: nbqa-black
       - id: nbqa-isort
+  - repo: https://github.com/roy-ht/pre-commit-jupyter
+    rev: v1.2.1
+    hooks:
+      - id: jupyter-notebook-cleanup
+        #args:
+          #- --remove-kernel-metadata

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,5 +54,5 @@ repos:
     rev: v1.2.1
     hooks:
       - id: jupyter-notebook-cleanup
-        #args:
-          #- --remove-kernel-metadata
+        args:
+          - --remove-kernel-metadata

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,8 +6,7 @@
 
 # Local build command ------------------------------------------------------------------
 
-# sphinx-build -W -n -b html -d build/doctrees doc build/html --keep-going
-# -D nbsphinx_kernel_name="weldx" -D nbsphinx_execute="never"
+# sphinx-build -W -n -b html -d build/doctrees doc build/html --keep-going -D nbsphinx_execute="never"
 
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -20,8 +19,6 @@ import pathlib
 import shutil
 import sys
 import typing
-
-import traitlets
 
 
 def _workaround_imports_typechecking():
@@ -150,21 +147,9 @@ master_doc = "index"
 nbsphinx_execute = "always"
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
+    "--InlineBackend.rc <figure.dpi=96>",
 ]
 
-if traitlets.__version__ < "5":
-    nbsphinx_execute_arguments.append("--InlineBackend.rc={'figure.dpi': 96}")
-else:
-    nbsphinx_execute_arguments.append("--InlineBackend.rc <figure.dpi=96>")
-
-# Select notebook kernel for nbsphinx
-# default "python3" is needed for readthedocs run
-# if building locally, this might need to be "weldx" - try setting using -D option:
-# -D nbsphinx_kernel_name="weldx"
-if os.getenv("READTHEDOCS", False):
-    nbsphinx_kernel_name = "python3"
-else:
-    nbsphinx_kernel_name = "weldx"
 
 # This is processed by Jinja2 and inserted before each notebook
 nbsphinx_prolog = r"""

--- a/tutorials/GMAW_process.ipynb
+++ b/tutorials/GMAW_process.ipynb
@@ -151,9 +151,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/custom_metadata.ipynb
+++ b/tutorials/custom_metadata.ipynb
@@ -102,9 +102,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/experiment_design_01.ipynb
+++ b/tutorials/experiment_design_01.ipynb
@@ -476,9 +476,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/geometry_01_profiles.ipynb
+++ b/tutorials/geometry_01_profiles.ipynb
@@ -901,9 +901,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/geometry_02_geometry.ipynb
+++ b/tutorials/geometry_02_geometry.ipynb
@@ -477,9 +477,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/groove_types_01.ipynb
+++ b/tutorials/groove_types_01.ipynb
@@ -255,9 +255,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/measurement_chain.ipynb
+++ b/tutorials/measurement_chain.ipynb
@@ -570,9 +570,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/measurement_example.ipynb
+++ b/tutorials/measurement_example.ipynb
@@ -511,9 +511,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/quality_standards.ipynb
+++ b/tutorials/quality_standards.ipynb
@@ -635,9 +635,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/timeseries_01.ipynb
+++ b/tutorials/timeseries_01.ipynb
@@ -369,9 +369,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/transformations_01_coordinate_systems.ipynb
+++ b/tutorials/transformations_01_coordinate_systems.ipynb
@@ -1006,9 +1006,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/transformations_02_coordinate_system_manager.ipynb
+++ b/tutorials/transformations_02_coordinate_system_manager.ipynb
@@ -893,9 +893,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/welding_example_01_basics.ipynb
+++ b/tutorials/welding_example_01_basics.ipynb
@@ -567,9 +567,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx-dev"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/welding_example_02_weaving.ipynb
+++ b/tutorials/welding_example_02_weaving.ipynb
@@ -620,9 +620,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "weldx",
+   "display_name": "",
    "language": "python",
-   "name": "weldx"
+   "name": ""
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Changes

Added clean notebook output hook. Tested locally, works like a charm.

There is an additional argument to remove kernel metadata (e.g. the constant switching of the Python version, depending on the devs local version). But this also removed the name of the env "weldx". So I'm not sure if this would break something. That's why I just disabled it.
