### PR TITLE
[wxfile] impl inline array threshold

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.0
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@
 added
 =====
 
+- `WeldxFile` handles an ``array_inline_threshold`` parameter to indicate if short arrays
+  will be serialized as strings, or as binary block. Note that this not affect arrays,
+  which are being shared across several objects in the same file.
+  `[#643] <https://github.com/BAMWelDX/weldx/pull/643>`__
+
+
 removed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ added
 =====
 
 - `WeldxFile` handles an ``array_inline_threshold`` parameter to indicate if short arrays
-  will be serialized as strings, or as binary block. Note that this not affect arrays,
+  will be serialized as strings, or as binary block. Note that this does not affect arrays,
   which are being shared across several objects in the same file.
   `[#643] <https://github.com/BAMWelDX/weldx/pull/643>`__
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -3,7 +3,6 @@ import copy
 import io
 import pathlib
 import warnings
-
 from collections.abc import MutableMapping, ValuesView
 from contextlib import contextmanager
 from io import BytesIO, IOBase
@@ -23,7 +22,7 @@ from typing import (
 
 import asdf
 import numpy as np
-from asdf import AsdfFile, generic_io, config_context
+from asdf import AsdfFile, config_context, generic_io
 from asdf import open as open_asdf
 from asdf.exceptions import AsdfWarning
 from asdf.tags.core import Software

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -145,8 +145,8 @@ class WeldxFile(_ProtectedViewDict):
         large datasets.
     array_inline_threshold :
         arrays below this threshold will be serialized as string, if larger as binary
-        block. Note that this does not affect arrays, which are being shared across several
-        objects in the same file.
+        block. Note that this does not affect arrays, which are being shared across
+        several objects in the same file.
 
     Examples
     --------

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -23,7 +23,7 @@ from typing import (
 
 import asdf
 import numpy as np
-from asdf import AsdfFile, generic_io
+from asdf import AsdfFile, generic_io, config_context
 from asdf import open as open_asdf
 from asdf.exceptions import AsdfWarning
 from asdf.tags.core import Software
@@ -48,6 +48,7 @@ __all__ = [
     "WeldxFile",
     "DEFAULT_ARRAY_COMPRESSION",
     "DEFAULT_ARRAY_COPYING",
+    "DEFAULT_ARRAY_INLINE_THRESHOLD",
     "_PROTECTED_KEYS",
 ]
 
@@ -72,6 +73,9 @@ DEFAULT_ARRAY_COMPRESSION = "input"
 
 DEFAULT_ARRAY_COPYING = True
 """Stored Arrays will be copied to memory, or not. If False, use memory mapping."""
+
+DEFAULT_ARRAY_INLINE_THRESHOLD = 10
+"""Arrays with less or equal elements will be inlined (stored as string, not binary)."""
 
 _PROTECTED_KEYS = (
     "history",
@@ -140,6 +144,10 @@ class WeldxFile(_ProtectedViewDict):
         When `False`, when reading files, attempt to memory map (memmap) underlying data
         arrays when possible. This avoids blowing the memory when working with very
         large datasets.
+    array_inline_threshold :
+        arrays below this threshold will be serialized as string, if larger as binary
+        block. Note that this not affect arrays, which are being shared across several
+        objects in the same file.
 
     Examples
     --------
@@ -205,12 +213,16 @@ class WeldxFile(_ProtectedViewDict):
         software_history_entry: Mapping = None,
         compression: str = DEFAULT_ARRAY_COMPRESSION,
         copy_arrays: bool = DEFAULT_ARRAY_COPYING,
+        array_inline_threshold: int = DEFAULT_ARRAY_INLINE_THRESHOLD,
     ):
         if write_kwargs is None:
             write_kwargs = dict(all_array_compression=compression)
 
         if asdffile_kwargs is None:
             asdffile_kwargs = dict(copy_arrays=copy_arrays)
+
+        # this parameter is now (asdf-2.8) a asdf.config parameter, so we store it here.
+        self._array_inline_threshold = array_inline_threshold
 
         # TODO: ensure no mismatching args for compression and copy_arrays.
         self._write_kwargs = write_kwargs
@@ -301,6 +313,21 @@ class WeldxFile(_ProtectedViewDict):
         # initialize protected key interface.
         super().__init__(protected_keys=_PROTECTED_KEYS, data=self._asdf_handle.tree)
 
+    @contextmanager
+    def _config_context(self, **kwargs):
+        # Temporarily set (default) options in asdf.config_context. This is useful
+        # during writing/updating data.
+        if (
+            "array_inline_threshold" not in kwargs
+            or kwargs["array_inline_threshold"] is None
+        ):
+            kwargs["array_inline_threshold"] = self._array_inline_threshold
+
+        with config_context() as config:
+            for k, v in kwargs.items():
+                setattr(config, k, v)
+            yield
+
     def _write_tree(
         self, filename_or_path_like, tree, asdffile_kwargs, write_kwargs, created
     ) -> AsdfFile:
@@ -311,7 +338,8 @@ class WeldxFile(_ProtectedViewDict):
         # 2. file exists, but should be updated with new tree
         if created:
             asdf_file = asdf.AsdfFile(tree=tree, **asdffile_kwargs)
-            asdf_file.write_to(filename_or_path_like, **write_kwargs)
+            with self._config_context():
+                asdf_file.write_to(filename_or_path_like, **write_kwargs)
             generic_file = generic_io.get_file(filename_or_path_like, mode="rw")
             asdf_file._fd = generic_file
         else:
@@ -319,7 +347,8 @@ class WeldxFile(_ProtectedViewDict):
                 raise RuntimeError("inconsistent mode, need to write data.")
             asdf_file = open_asdf(filename_or_path_like, **asdffile_kwargs, mode="rw")
             asdf_file.tree = tree
-            asdf_file.update(**write_kwargs)
+            with self._config_context():
+                asdf_file.update(**write_kwargs)
         return asdf_file
 
     @property
@@ -455,14 +484,14 @@ class WeldxFile(_ProtectedViewDict):
         **kwargs,
     ):
         """Get this docstring overwritten by AsdfFile.update."""
-        self._asdf_handle.update(
-            all_array_storage=all_array_storage,
-            all_array_compression=all_array_compression,
-            pad_blocks=pad_blocks,
-            include_block_index=include_block_index,
-            version=version,
-            **kwargs,
-        )
+        with self._config_context(**kwargs):
+            self._asdf_handle.update(
+                all_array_storage=all_array_storage,
+                all_array_compression=all_array_compression,
+                pad_blocks=pad_blocks,
+                include_block_index=include_block_index,
+                version=version,
+            )
 
     sync.__doc__ = AsdfFile.update.__doc__
 
@@ -720,6 +749,7 @@ class WeldxFile(_ProtectedViewDict):
             write_kwargs=self._write_kwargs,
             sync=self.sync_upon_close,
             software_history_entry=self.software_history_entry,
+            array_inline_threshold=self._array_inline_threshold,
         )
         return wx
 
@@ -759,7 +789,10 @@ class WeldxFile(_ProtectedViewDict):
         return AttrDict(self)
 
     def write_to(
-        self, fd: Optional[types_path_and_file_like] = None, **write_args
+        self,
+        fd: Optional[types_path_and_file_like] = None,
+        array_inline_threshold=None,
+        **write_args,
     ) -> Optional[types_path_and_file_like]:
         """Write current contents to given file name or file type.
 
@@ -769,6 +802,10 @@ class WeldxFile(_ProtectedViewDict):
             May be a string path to a file, or a Python file-like
             object. If a string path, the file is automatically
             closed after writing. If `None` is given, write to a new buffer.
+
+        array_inline_threshold :
+            arrays below this threshold will be serialized as string, if
+            larger as binary block.
 
         write_args :
             Allowed parameters:
@@ -793,7 +830,8 @@ class WeldxFile(_ProtectedViewDict):
         if not write_args:
             write_args = self._write_kwargs
 
-        self._asdf_handle.write_to(fd, **write_args)
+        with self._config_context(array_inline_threshold=array_inline_threshold):
+            self._asdf_handle.write_to(fd, **write_args)
 
         if isinstance(fd, types_file_like.__args__):
             fd.seek(0)

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -145,7 +145,7 @@ class WeldxFile(_ProtectedViewDict):
         large datasets.
     array_inline_threshold :
         arrays below this threshold will be serialized as string, if larger as binary
-        block. Note that this not affect arrays, which are being shared across several
+        block. Note that this does not affect arrays, which are being shared across several
         objects in the same file.
 
     Examples

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -502,10 +502,10 @@ class TestWeldXFile:
             f.update()
             f.close()
 
-        # compare data
+        # file sizes should be almost equal (array inlining in wxfile).
         assert (
             pathlib.Path("test.asdf").stat().st_size
-            == pathlib.Path("test.wx").stat().st_size
+            >= pathlib.Path("test.wx").stat().st_size
         )
 
         def _read(fn):

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -503,16 +503,17 @@ class TestWeldXFile:
             f.close()
 
         # file sizes should be almost equal (array inlining in wxfile).
-        assert (
-            pathlib.Path("test.asdf").stat().st_size
-            >= pathlib.Path("test.wx").stat().st_size
-        )
+        a = pathlib.Path("test.asdf").stat().st_size
+        b = pathlib.Path("test.wx").stat().st_size
+        assert a >= b
 
-        def _read(fn):
-            with open(fn, "br") as fh:
-                return fh.read()
+        if a == b:
 
-        assert _read("test.asdf") == _read("test.wx")
+            def _read(fn):
+                with open(fn, "br") as fh:
+                    return fh.read()
+
+            assert _read("test.asdf") == _read("test.wx")
 
     @pytest.mark.parametrize("protected_key", _PROTECTED_KEYS)
     def test_cannot_update_del_protected_keys(self, protected_key):

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -588,7 +588,3 @@ class TestWeldXFile:
             array_inline_threshold=len(x) + 1
         )
         assert b"BLOCK" not in buff.read()
-
-    @staticmethod
-    def test_array_inline_threshold_():
-        pass


### PR DESCRIPTION
## Changes

ASDF 2.8 introduced the config context and deprecated this as a plain argument. However in the wrapper I think it'd be a sane solution to have it as an (optional) parameter again. It is delegated to the temporary config context.

## Related Issues

Closes #601 

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
