### PR TITLE
add unit handling to `Trace.plot´

### DIFF
--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -1829,7 +1829,7 @@ class Trace:
             Set plot axes to equal scaling (Default = False).
 
         """
-        data = self.rasterize(raster_width).to("mm")
+        data = self.rasterize(raster_width).to(_DEFAULT_LEN_UNIT)
         if fmt is None:
             fmt = "x-"
         if axes is None:
@@ -1837,9 +1837,9 @@ class Trace:
 
             _, axes = subplots(subplot_kw=dict(projection="3d", proj_type="ortho"))
             axes.plot(data[0].m, data[1].m, data[2].m, fmt)
-            axes.set_xlabel("x / mm")
-            axes.set_ylabel("y / mm")
-            axes.set_zlabel("z / mm")
+            axes.set_xlabel(f"x / {_DEFAULT_LEN_UNIT}")
+            axes.set_ylabel(f"y / {_DEFAULT_LEN_UNIT}")
+            axes.set_zlabel(f"z / {_DEFAULT_LEN_UNIT}")
             if axes_equal:
                 import weldx.visualization as vs
 

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -1829,23 +1829,23 @@ class Trace:
             Set plot axes to equal scaling (Default = False).
 
         """
-        data = self.rasterize(raster_width)
+        data = self.rasterize(raster_width).to("mm")
         if fmt is None:
             fmt = "x-"
         if axes is None:
             from matplotlib.pyplot import subplots
 
             _, axes = subplots(subplot_kw=dict(projection="3d", proj_type="ortho"))
-            axes.plot(data[0], data[1], data[2], fmt)
-            axes.set_xlabel("x")
-            axes.set_ylabel("y")
-            axes.set_zlabel("z")
+            axes.plot(data[0].m, data[1].m, data[2].m, fmt)
+            axes.set_xlabel("x / mm")
+            axes.set_ylabel("y / mm")
+            axes.set_zlabel("z / mm")
             if axes_equal:
                 import weldx.visualization as vs
 
                 vs.axes_equal(axes)
         else:
-            axes.plot(data[0], data[1], data[2], fmt)
+            axes.plot(data[0].m, data[1].m, data[2].m, fmt)
 
 
 # Linear profile interpolation class ------------------------------------------

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -17,7 +17,7 @@ from weldx.asdf.cli.welding_schema import single_pass_weld_example
 from weldx.asdf.file import _PROTECTED_KEYS
 from weldx.asdf.util import get_schema_path
 from weldx.types import SupportsFileReadWrite
-from weldx.util import compare_nested
+from weldx.util import WeldxDeprecationWarning, compare_nested
 
 SINGLE_PASS_SCHEMA = "single_pass_weld-0.1.0"
 
@@ -521,8 +521,9 @@ class TestWeldXFile:
         """Ensure we cannot manipulate protected keys."""
         expected_match = "manipulate an ASDF internal structure"
         warning_type = UserWarning
-        with pytest.raises(KeyError):  # try to obtain key from underlying dict.
-            _ = self.fh.data[protected_key]
+        with pytest.warns(WeldxDeprecationWarning):
+            with pytest.raises(KeyError):  # try to obtain key from underlying dict.
+                _ = self.fh.data[protected_key]
 
         with pytest.warns(warning_type, match=expected_match):
             self.fh.update({protected_key: None})

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -521,9 +521,9 @@ class TestWeldXFile:
         """Ensure we cannot manipulate protected keys."""
         expected_match = "manipulate an ASDF internal structure"
         warning_type = UserWarning
-        with pytest.warns(WeldxDeprecationWarning):
-            with pytest.raises(KeyError):  # try to obtain key from underlying dict.
-                _ = self.fh.data[protected_key]
+        # try to obtain key from underlying dict.
+        with pytest.raises(KeyError), pytest.warns(WeldxDeprecationWarning):
+            _ = self.fh.data[protected_key]
 
         with pytest.warns(warning_type, match=expected_match):
             self.fh.update({protected_key: None})

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -514,6 +514,7 @@ class TestWeldXFile:
 
         assert _read("test.asdf") == _read("test.wx")
 
+    @pytest.mark.filterwarnings("ignore:You tried to manipulate an ASDF internal")
     @pytest.mark.parametrize("protected_key", _PROTECTED_KEYS)
     def test_cannot_update_del_protected_keys(self, protected_key):
         """Ensure we cannot manipulate protected keys."""

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -515,6 +515,7 @@ class TestWeldXFile:
         assert _read("test.asdf") == _read("test.wx")
 
     @pytest.mark.filterwarnings("ignore:You tried to manipulate an ASDF internal")
+    @pytest.mark.filterwarnings("ignore:Call to deprecated function data.")
     @pytest.mark.parametrize("protected_key", _PROTECTED_KEYS)
     def test_cannot_update_del_protected_keys(self, protected_key):
         """Ensure we cannot manipulate protected keys."""


### PR DESCRIPTION
## Changes
handle units in `Trace.plot`

might also fix the current pytest errors if we're lucky

(also cleans up some expected pytest warnings)