### PR TITLE
use numpy typing for ArrayLike

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -1,4 +1,4 @@
-name: build
+name: package builds
 on:
   push:
     branches:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: documentation
+name: documentation builds
 on:
   push:
     branches:
@@ -23,6 +23,7 @@ jobs:
       (github.event.pull_request.draft == false) ||
       (github.event_name == 'workflow_dispatch') ||
       (github.ref == 'refs/heads/master')
+    name: sphinx build
     runs-on: ubuntu-latest
     env:
       nbsphinx_execute: 'always'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ deprecations
 dependencies
 ============
 
+-  bump to numpy >=1.20 (for numpy.typing)
+
 ********************
  0.5.2 (18.11.2021)
 ********************

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -11,7 +11,7 @@ py:class weldx.asdf.types.WeldxConverter
 
 # numpy typing
 py:class numpy.typing._array_like._SupportsArray
-py:class numpy.typing._array_like._SupportsArray
+py:class npt.ArrayLike
 
 # matplotlib
 py:class matplotlib.axes.Axes

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -9,6 +9,9 @@ py:obj weldx.GmawProcess.parameters
 py:class types_path_and_file_like
 py:class weldx.asdf.types.WeldxConverter
 
+# numpy typing
+py:class numpy.typing._array_like._SupportsArray
+
 # matplotlib
 py:class matplotlib.axes.Axes
 py:class matplotlib.axes._axes.Axes

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -11,6 +11,7 @@ py:class weldx.asdf.types.WeldxConverter
 
 # numpy typing
 py:class numpy.typing._array_like._SupportsArray
+py:class numpy.typing._array_like._SupportsArray
 
 # matplotlib
 py:class matplotlib.axes.Axes

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ setup_requires =
     setuptools >=38.3.0
     setuptools_scm
 install_requires =
-    numpy >=1.18
+    numpy >=1.20
     pandas >=1.0
     xarray >=0.15
     scipy >=1.4,!=1.6.0,!=1.6.1

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import meshio
 import numpy as np
+import numpy.typing as npt
 import pint
 from xarray import DataArray
 
@@ -24,7 +25,6 @@ _DEFAULT_ANG_UNIT = UREG.rad
 # only import heavy-weight packages on type checking
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib.axes
-    import numpy.typing as npt
 
     import weldx.visualization.types as vs_types
     import weldx.welding.groove.iso_9692_1 as iso

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -24,6 +24,7 @@ _DEFAULT_ANG_UNIT = UREG.rad
 # only import heavy-weight packages on type checking
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib.axes
+    import numpy.typing as npt
 
     import weldx.visualization.types as vs_types
     import weldx.welding.groove.iso_9692_1 as iso
@@ -2518,10 +2519,10 @@ class Geometry:
 class SpatialData:
     """Represent 3D point cloud data with optional triangulation."""
 
-    coordinates: DataArray
+    coordinates: Union[DataArray, npt.ArrayLike]
     """3D array of point data.
         The expected array dimension order is [("time"), "n", "c"]."""
-    triangles: np.ndarray = None
+    triangles: npt.ArrayLike = None
     """3D Array of triangulation connectivity.
         Shape should be [time * n, 3]."""
     attributes: Dict[str, np.ndarray] = None

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import meshio
 import numpy as np
-import numpy.typing as npt
 import pint
 from xarray import DataArray
 
@@ -25,6 +24,7 @@ _DEFAULT_ANG_UNIT = UREG.rad
 # only import heavy-weight packages on type checking
 if TYPE_CHECKING:  # pragma: no cover
     import matplotlib.axes
+    import numpy.typing as npt
 
     import weldx.visualization.types as vs_types
     import weldx.welding.groove.iso_9692_1 as iso

--- a/weldx/transformations/rotation.py
+++ b/weldx/transformations/rotation.py
@@ -1,13 +1,15 @@
 """Contains tools to handle rotations."""
 
-from typing import List, Union
+from typing import TYPE_CHECKING, Union
 
-import numpy as np
 import pint
 from scipy.spatial.transform import Rotation as _Rotation
 
 from weldx.constants import U_
 from weldx.constants import WELDX_UNIT_REGISTRY as UREG
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 _DEFAULT_LEN_UNIT = UREG.millimeters
 _DEFAULT_ANG_UNIT = UREG.rad
@@ -20,7 +22,7 @@ class WXRotation(_Rotation):
     """
 
     @classmethod
-    def from_quat(cls, quat: np.ndarray) -> "WXRotation":  # noqa
+    def from_quat(cls, quat: npt.ArrayLike) -> "WXRotation":  # noqa
         """Initialize from quaternions.
 
         See `scipy.spatial.transform.Rotation.from_quat` docs for details.
@@ -30,7 +32,7 @@ class WXRotation(_Rotation):
         return rot
 
     @classmethod
-    def from_matrix(cls, matrix: np.ndarray) -> "WXRotation":  # noqa
+    def from_matrix(cls, matrix: npt.ArrayLike) -> "WXRotation":  # noqa
         """Initialize from matrix.
 
         See `scipy.spatial.transform.Rotation.from_matrix` docs for details.
@@ -40,7 +42,7 @@ class WXRotation(_Rotation):
         return rot
 
     @classmethod
-    def from_rotvec(cls, rotvec: np.ndarray) -> "WXRotation":  # noqa
+    def from_rotvec(cls, rotvec: npt.ArrayLike) -> "WXRotation":  # noqa
         """Initialize from rotation vector.
 
         See `scipy.spatial.transform.Rotation.from_rotvec` docs for details.
@@ -54,7 +56,7 @@ class WXRotation(_Rotation):
     def from_euler(
         cls,
         seq: str,
-        angles: Union[pint.Quantity, np.ndarray, List[float], List[List[float]]],
+        angles: Union[pint.Quantity, npt.ArrayLike],
         degrees: bool = False,
     ) -> "WXRotation":  # noqa
         """Initialize from euler angles.

--- a/weldx/transformations/rotation.py
+++ b/weldx/transformations/rotation.py
@@ -1,4 +1,5 @@
 """Contains tools to handle rotations."""
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Union
 

--- a/weldx/transformations/types.py
+++ b/weldx/transformations/types.py
@@ -1,12 +1,12 @@
 """shared type definitions."""
-from typing import List, Union
+from typing import Union
 
-import numpy as np
+import numpy.typing as npt
 import xarray as xr
 from scipy.spatial.transform import Rotation
 
-types_coordinates = Union[xr.DataArray, np.ndarray, List]
-types_orientation = Union[xr.DataArray, np.ndarray, List[List], Rotation]
+types_coordinates = Union[xr.DataArray, npt.ArrayLike]
+types_orientation = Union[xr.DataArray, npt.ArrayLike, Rotation]
 
 
 __all__ = [

--- a/weldx/types.py
+++ b/weldx/types.py
@@ -3,6 +3,10 @@ import pathlib
 from io import IOBase
 from typing import Protocol, Union, runtime_checkable
 
+import numpy.typing as npt
+import pint
+import xarray as xr
+
 __all__ = [
     "SupportsFileReadOnly",
     "SupportsFileReadWrite",
@@ -55,3 +59,5 @@ types_path_like = Union[str, pathlib.Path]
 
 types_path_and_file_like = Union[types_path_like, types_file_like]
 """types to handle paths and file handles."""
+
+ArrayLike = Union[npt.ArrayLike, xr.DataArray, pint.Quantity]

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,9 @@ from scipy.spatial.transform import Slerp
 from weldx.constants import Q_, U_
 from weldx.constants import WELDX_UNIT_REGISTRY as ureg
 from weldx.time import Time, types_time_like, types_timestamp_like
+
+if TYPE_CHECKING:
+    import weldx.types as wxt
 
 __all__ = [
     "WeldxAccessor",
@@ -514,7 +517,7 @@ def xr_check_coords(dax: xr.DataArray, ref: dict) -> bool:
 
 
 def xr_3d_vector(
-    data: np.ndarray,
+    data: wxt.ArrayLike,
     time: types_time_like = None,
     add_dims: List[str] = None,
     add_coords: Dict[str, Any] = None,
@@ -570,7 +573,7 @@ def xr_3d_vector(
     return da.astype(float).weldx.time_ref_restore()
 
 
-def xr_3d_matrix(data: np.ndarray, time: Time = None) -> xr.DataArray:
+def xr_3d_matrix(data: wxt.ArrayLike, time: Time = None) -> xr.DataArray:
     """Create an xarray 3d matrix with correctly named dimensions and coordinates.
 
     Parameters

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -18,7 +18,7 @@ from weldx.constants import Q_, U_
 from weldx.constants import WELDX_UNIT_REGISTRY as ureg
 from weldx.time import Time, types_time_like, types_timestamp_like
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import weldx.types as wxt
 
 __all__ = [


### PR DESCRIPTION
Numpy introduced a `numpy.typing` module in `1.20` that should simplify a lot of our type hints
Here is an initial implementation to test what mypy things of this 😉 

## Changes
- use `numpy.typing.ArrayLike` for type hints
- bump numpy dependency to >=1.20

## Related Issues

Closes # (add issue numbers)

## Checks

- [x] updated CHANGELOG.rst
