### PR TITLE
wx_property_tag list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ removed
 changes
 =======
 
--  The ``wx_property_tag`` validator now also accepts lists of different tags.
+-  The ``wx_property_tag`` validator now also accepts lists of different tags. [:pull:`670`]
    When multiple tags are passed, validation will pass if *one or more* of the supplied pattern matches.
 
 fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ removed
 changes
 =======
 
+-  The ``wx_property_tag`` validator now also accepts lists of different tags.
+   When multiple tags are passed, validation will pass if *one or more* of the supplied pattern matches.
+
 fixes
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ changes
 =======
 
 -  The ``wx_property_tag`` validator now also accepts lists of different tags. [:pull:`670`]
-   When multiple tags are passed, validation will pass if *one or more* of the supplied pattern matches.
+   When multiple tags are passed, validation will fail if *none* of the supplied patterns match.
 
 fixes
 =====

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -4,10 +4,9 @@ from typing import Any, Callable, Dict, Iterator, List, Mapping, OrderedDict, Un
 
 from asdf import ValidationError
 from asdf.schema import _type_to_tag
-from asdf.util import uri_match
 
 from weldx.asdf.types import WxSyntaxError
-from weldx.asdf.util import _get_instance_shape
+from weldx.asdf.util import _get_instance_shape, uri_match
 from weldx.constants import U_
 
 __all__ = ["wx_unit_validator", "wx_shape_validator", "wx_property_tag_validator"]
@@ -583,7 +582,7 @@ def wx_shape_validator(
 
 
 def wx_property_tag_validator(
-    validator, wx_property_tag: str, instance, schema
+    validator, wx_property_tag: Union[str, List[str]], instance, schema
 ) -> Iterator[ValidationError]:
     """
 
@@ -617,6 +616,11 @@ def wx_property_tag_validator(
                 yield ValidationError(
                     f"mismatched tags, wanted '{tagname}', got '{instance_tag}'"
                 )
+
+    if not isinstance(wx_property_tag, (str, list)):
+        raise WxSyntaxError(
+            f"'wx_property_tag' must be str or List[str], got {wx_property_tag}"
+        )
 
     for _, value in instance.items():
         yield from _tag_validator(tagname=wx_property_tag, instance=value)

--- a/weldx/schemas/weldx.bam.de/weldx/debug/test_property_tag-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/debug/test_property_tag-0.1.0.yaml
@@ -11,5 +11,7 @@ description: |
   So far only one specific tag can be used.
 type: object
 additionalProperties: true # must be true to allow any property
-wx_property_tag: "asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.*"
+wx_property_tag:
+  - "asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.*"
+  - "asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.*"
 ...

--- a/weldx/tags/debug/test_property_tag.py
+++ b/weldx/tags/debug/test_property_tag.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 
 import pandas as pd
+import pint
 
 from weldx.asdf.util import dataclass_serialization_class
+from weldx.constants import Q_
 
 __all__ = ["PropertyTagTestClass", "PropertyTagTestClassConverter"]
 
@@ -13,7 +15,7 @@ class PropertyTagTestClass:
 
     prop1: pd.Timestamp = pd.Timestamp("2020-01-01")
     prop2: pd.Timestamp = pd.Timestamp("2020-01-02")
-    prop3: pd.Timestamp = pd.Timestamp("2020-01-03")
+    prop3: pint.Quantity = Q_("3m")
 
 
 PropertyTagTestClassConverter = dataclass_serialization_class(


### PR DESCRIPTION
## Changes

- The ``wx_property_tag`` validator now also accepts lists of different tags (or tag patterns).

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests

