### PR TITLE
set meshio<5.2 for sphinx builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
         # So the initial env creation lacks weldx, so we install it here.
         shell: bash -l {0}
-        run: pwd && pip install -e . && pip install git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
+        run: pwd && pip install -e .
 
       - name: conda info
         shell: bash -l {0}

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -28,6 +28,8 @@ dependencies:
   - typing_extensions
   # GH332
   - docutils=0.16
+  # GH672
+  - meshio<5.2
   # pip packages
   - pip
   - pip:


### PR DESCRIPTION
## Changes
- set `meshio<5.2` in the sphinx environment to avoid import error
https://github.com/BAMWelDX/weldx/runs/4570280776?check_suite_focus=true

## Related Issues

Closes #672

I am not sure why this only pops up in the sphinx build, do we have a test using meshio? @vhirtham 