### PR TITLE
Prevent circular ImportError meshio

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
         # So the initial env creation lacks weldx, so we install it here.
         shell: bash -l {0}
-        run: pwd && pip install -e . && pip install git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
+        run: pwd && pip install -e .
 
       - name: conda info
         shell: bash -l {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,7 @@ jobs:
         # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
         # So the initial env creation lacks weldx, so we install it here.
         shell: bash -l {0}
-        run: pwd && pip install -e .
+        run: pwd && pip install -e . && pip install git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
 
       - name: conda info
         shell: bash -l {0}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,8 +26,16 @@ logger = getLogger("weldx_sphinx_conf")
 
 
 def _workaround_imports_typechecking():
-    """Load some packages needed for type annotations."""
+    """Load some packages needed for type annotations.
+
+    If these packages are imported implicitly via the import of weldx,
+    we see circular import errors within these packages. This could be due to
+    the fact, that Sphinx `exec` this config file with its own globals dictionary.
+
+    So this workaround function has to be executed prior importing weldx.
+    """
     import ipywidgets  # noqa
+    import meshio  # noqa
     import pandas  # noqa
     import pint  # noqa
     import xarray  # noqa
@@ -43,7 +51,7 @@ def _prevent_sphinx_circular_imports_bug():
 
 
 _prevent_sphinx_circular_imports_bug()
-_workaround_imports_typechecking()
+_workaround_imports_typechecking()  # needs to be called prior importing weldx.
 
 typing.TYPE_CHECKING = True
 try:
@@ -57,6 +65,7 @@ except Exception as ex:
 import weldx.visualization  # load visualization (currently no auto-import in pkg).
 
 tutorials_dir = (pathlib.Path(__file__).parent / "./tutorials").absolute()
+logger.info("tutorials dir: %s", tutorials_dir)
 
 
 # -- copy tutorial files to doc folder -------------------------------------------------
@@ -74,8 +83,6 @@ def _copy_tut_files():
 _copy_tut_files()
 
 
-tutorials_dir = (pathlib.Path(__file__).parent / "./tutorials").absolute()
-logger.info("tutorials dir: %s", tutorials_dir)
 # TODO: git move tutorial files to tutorials_dir!
 tutorial_files = pathlib.Path("./../tutorials/").glob("*.ipynb")
 for f in tutorial_files:

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -11,6 +11,7 @@ py:class weldx.asdf.types.WeldxConverter
 
 # numpy typing
 py:class numpy.typing._array_like._SupportsArray
+py:class numpy.typing._nested_sequence._NestedSequence
 py:class npt.ArrayLike
 
 # matplotlib

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -28,8 +28,6 @@ dependencies:
   - typing_extensions
   # GH332
   - docutils=0.16
-  # GH672
-  - meshio<5.2
   # pip packages
   - pip
   - pip:


### PR DESCRIPTION
## Changes

Preload meshio to avoid Sphinx circular ImportError. 

This issue might arise from the fact, that the conf.py file is being passed to exec with its own globals dictionary. This is why we only observe these import errors in Sphinx, but not during daily usage of weldx. Perhaps we should report this upstream.

Follow up to #673 

## Checks
- [x] updated doc/
