### PR TITLE
add time_series-0.1.1.yaml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ changes
 fixes
 =====
 
+-  `TimeSeries` can now be serialized correctly when using absolute times [:pull:`677`]
+
 documentation
 =============
 
@@ -43,6 +45,8 @@ ASDF
 -  update ``core/geometry/spatial_data`` to version ``0.1.1`` with support for multidimensional data [:pull:`655`]
 
 -  add ``wx_shape`` validation support for ``core/data_array`` [:pull:`655`]
+
+-  update ``core/time_series`` schema to use ``time/time`` [:pull:`677`]
 
 deprecations
 ============

--- a/weldx/manifests/weldx-0.1.1.yaml
+++ b/weldx/manifests/weldx-0.1.1.yaml
@@ -47,6 +47,8 @@ tags:
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/mathematical_expression-0.1.0
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/time_series-0.1.0
+- tag_uri: asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1
+  schema_uri: asdf://weldx.bam.de/weldx/schemas/core/time_series-0.1.1
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/variable-0.1.0
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.0

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
@@ -1,0 +1,108 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://weldx.bam.de/weldx/schemas/core/time_series-0.1.1"
+
+title: |
+  Schema that describes a time series.
+description: |
+  Describes a time dependent quantity.
+
+examples:
+  -
+    - A time_series describing a constant value in time.
+    - |
+      !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>
+        units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> millimeter / second
+        value: 10.0
+  -
+    - A time_series describing a sine oscillation in 3d space along the z-axis
+    - |
+      !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>
+        expression: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>
+          expression: a*sin(o*t + p) + b
+          parameters:
+            a: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0>
+              units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> millimeter
+              value: !core/ndarray-1.0.0
+                data:
+                - [0, 0, 1]
+                datatype: int32
+                shape: [1, 3]
+            b: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0> {value: 0.0, units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> millimeter}
+            o: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0> {value: 4.934802200544679, units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> hertz * radian}
+            p: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0> {value: 0, units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> radian}
+        units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> millimeter
+        shape: [1, 3]
+
+oneOf:
+  - type: object
+    description: |
+      Implementation for constant values.
+    properties:
+      value:
+        description: |
+          Number or n-dimensional array that is constant in time.
+        anyOf:
+          - type: number
+          - type: integer
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      units:
+        description: |
+          Unit of the data.
+        tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
+    required: [value, units]
+
+  - type: object
+    description: |
+      Implementation for expressions.
+    properties:
+      expression:
+        description: |
+          A mathematical expression that describes the time dependent behaviour.
+        tag: "asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.*"
+      units:
+        description: |
+          Resulting unit of the data when the expression is evaluated.
+        tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
+      shape:
+        description: |
+          (optional) Resulting shape of the data when the expression is evaluated.
+        type: array
+    required: [expression, units]
+
+  - type: object
+    description: |
+      Implementation for discrete data.
+    properties:
+      time:
+        description: |
+          The time axis associated with the data.
+        tag: "asdf://weldx.bam.de/weldx/tags/time/time-0.1.*"
+      units:
+        description: |
+          Units of the data.
+        tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
+      shape:
+        description: |
+          Shape of the data.
+        type: array
+      interpolation:
+        description: |
+          Method how the data should be interpolated.
+        type: string
+        enum: [linear, step]
+      values:
+        description: |
+          Set of discrete n-dimensional data.
+        tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    wx_shape:
+      #description: |
+      #  The outer dimension of the data needs to be identical to the times dimension.
+      time: [t]
+      values: [t, ...]
+    required: [time, units, shape, interpolation, values]
+
+propertyOrder: [expression, values, time, units, shape, interpolation, values]
+flowStyle: block
+...

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
@@ -16,6 +16,22 @@ examples:
         units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> millimeter / second
         value: 10.0
   -
+    - A time series of 4 discrete points
+    - |
+      !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>
+        values: !core/ndarray-1.0.0
+          data: [1, 2, 3, 8]
+          datatype: int32
+          shape: [4]
+        time: !<asdf://weldx.bam.de/weldx/tags/time/time-0.1.0>
+          values: !<asdf://weldx.bam.de/weldx/tags/time/datetimeindex-0.1.0> {start: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> '2020-01-01T00:00:00',
+            end: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> '2020-01-04T00:00:00', freq: D, min: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> '2020-01-01T00:00:00',
+            max: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> '2020-01-04T00:00:00'}
+          reference_time: !<asdf://weldx.bam.de/weldx/tags/time/timestamp-0.1.0> 2020-01-01T00:00:00
+        units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> meter
+        shape: [4]
+        interpolation: step
+  -
     - A time_series describing a sine oscillation in 3d space along the z-axis
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
@@ -65,7 +65,7 @@ oneOf:
           - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
       units:
         description: |
-          Unit of the data.
+          Units of the data.
         tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
     required: [value, units]
 
@@ -79,7 +79,7 @@ oneOf:
         tag: "asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.*"
       units:
         description: |
-          Resulting unit of the data when the expression is evaluated.
+          Resulting units of the data when the expression is evaluated.
         tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
       shape:
         description: |

--- a/weldx/tags/time/time.py
+++ b/weldx/tags/time/time.py
@@ -21,3 +21,12 @@ class TimeConverter(WeldxConverter):
     def from_yaml_tree(self, node: dict, tag: str, ctx):
         """Construct Time from tree."""
         return Time(node["values"], node.get("reference_time"))
+
+    @staticmethod
+    def shape_from_tagged(node):
+        """Calculate the shape from static tagged tree instance."""
+        from weldx.asdf.util import _get_instance_shape
+
+        if "freq" in node["values"]:
+            return _get_instance_shape(node["values"])
+        return node["values"]["shape"]

--- a/weldx/tags/time/time.py
+++ b/weldx/tags/time/time.py
@@ -27,6 +27,4 @@ class TimeConverter(WeldxConverter):
         """Calculate the shape from static tagged tree instance."""
         from weldx.asdf.util import _get_instance_shape
 
-        if "freq" in node["values"]:
-            return _get_instance_shape(node["values"])
-        return node["values"]["shape"]
+        return _get_instance_shape(node["values"])

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -342,7 +342,7 @@ def test_coordinate_system_manager(copy_arrays, lazy_load):
 def get_coordinate_system_manager_with_subsystems(nested: bool):
     lcs = [tf.LocalCoordinateSystem(coordinates=[i, -i, -i]) for i in range(12)]
 
-    # global system
+    # create global system
     csm_global = tf.CoordinateSystemManager("base", "Global System", "2000-06-08")
     csm_global.add_cs("robot", "base", lcs[0])
     csm_global.add_cs("specimen", "base", lcs[1])

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -495,6 +495,14 @@ def test_coordinate_system_manager_with_data(copy_arrays, lazy_load):
         TimeSeries(Q_([42, 23, 12], "m"), time=pd.TimedeltaIndex([0, 2, 4])),
         TimeSeries(Q_([42, 23, 12], "m"), time=pd.TimedeltaIndex([0, 2, 5])),
         TimeSeries(ME("a*t+b", parameters={"a": Q_(2, "1/s"), "b": Q_(5, "")})),
+        TimeSeries(
+            Q_([1, 2, 3], "m"),
+            time=pd.date_range(start="2020-01-01", freq="1D", periods=3),
+        ),
+        TimeSeries(
+            Q_([1, 2, 3], "m"),
+            time=pd.DatetimeIndex(["2020", "2021", "2024"]),
+        ),
     ],
 )
 def test_time_series(ts, copy_arrays, lazy_load):


### PR DESCRIPTION
## Changes
- serialization of `TimeSeries` is now based on `Time` with support for absolute times (only serialized timedeltas before)
- added small test for absolute times
- added shape validation to `Time`

## Related Issues

Closes #671 

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [x] update manifest file
