### PR TITLE
fix time behavior in tests and filter warnings for pandas 1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ asdf_schema_root = weldx/schemas/weldx.bam.de/weldx
 norecursedirs = doc
 filterwarnings =
     ignore::DeprecationWarning:traittypes.*:
+    ignore:Passing method to :FutureWarning:xarray.*:
 
 [isort]
 profile = black

--- a/weldx/tests/test_time.py
+++ b/weldx/tests/test_time.py
@@ -336,6 +336,8 @@ class TestTime:
             np.ndarray,
             np.timedelta64,
             np.datetime64,
+            DTI,
+            TDI,
         ):
             return
 
@@ -419,7 +421,7 @@ class TestTime:
             return
 
         # skip __radd__ cases where we got conflicts with the other types' __add__
-        if not other_on_rhs and other_type in (Q_, np.ndarray, np.timedelta64):
+        if not other_on_rhs and other_type in (Q_, np.ndarray, np.timedelta64, TDI):
             return
 
         # setup rhs
@@ -535,6 +537,8 @@ class TestTime:
             np.ndarray,
             np.timedelta64,
             np.datetime64,
+            DTI,
+            TDI,
         ):
             return
 


### PR DESCRIPTION
## Changes
- Fix failing tests due to new pandas version ->seems like pandas added own `__add__` functions so that we couldn't use + with a pandas Type on the left-hand side and our Time class on the right-hand side (thanks @vhirtham )
- filter warnings caused by xarray introduced with pandas 1.4

## Checks

- [x] updated tests
