### PR TITLE
Rename wxfile asdf header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,11 +24,14 @@ removed
 changes
 =======
 
--  The ``wx_property_tag`` validator now also accepts lists of different tags. [:pull:`670`]
+- The ``wx_property_tag`` validator now also accepts lists of different tags. [:pull:`670`]
    When multiple tags are passed, validation will fail if *none* of the supplied patterns match.
 
 - Due to a `pandas` update, using the + operator with `Time` and either a `pandas.TimedeltaIndex` or `pandas.DatetimeIndex`
   now only works if the `Time` instance is on the left-hand side. [:pull:`684`]
+
+- Renamed show_asdf_header of `WeldxFile` to `WeldxFile.header`. [:pull:`694`]
+
 
 fixes
 =====

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -170,7 +170,7 @@ class WeldxFile(_ProtectedViewDict):
 
     We can have a look at the serialized data by looking at the asdf header
 
-    >>> wx2.show_asdf_header()  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
+    >>> wx2.header()  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
     #ASDF 1.0.0
     #ASDF_STANDARD 1.5.0
     %YAML 1.1
@@ -832,7 +832,7 @@ class WeldxFile(_ProtectedViewDict):
     def data(self):
         return self._data
 
-    def show_asdf_header(
+    def header(
         self,
         use_widgets: bool = None,
         path: tuple = None,
@@ -858,14 +858,18 @@ class WeldxFile(_ProtectedViewDict):
             Should not be set.
         """
         return _HeaderVisualizer(self._asdf_handle).show(
-            use_widgets=use_widgets, path=path, _interactive=_interactive
+            use_widgets=use_widgets, _interactive=_interactive
         )
+
+    @deprecated("0.6", "0.7", "Please use file.header() instead.")
+    def show_asdf_header(self, *args, **kwargs):
+        return self.header(*args, **kwargs)
 
     def _ipython_display_(self):
         # this will be called in Jupyter Lab, but not in a plain notebook.
         from IPython.core.display import display
 
-        display(self.show_asdf_header(use_widgets=True, _interactive=True))
+        display(self.header(use_widgets=True, _interactive=True))
 
     def info(
         self,

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -858,7 +858,7 @@ class WeldxFile(_ProtectedViewDict):
             Should not be set.
         """
         return _HeaderVisualizer(self._asdf_handle).show(
-            use_widgets=use_widgets, _interactive=_interactive
+            use_widgets=use_widgets, path=path, _interactive=_interactive
         )
 
     @deprecated("0.6", "0.7", "Please use file.header() instead.")

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -112,7 +112,7 @@ def write_buffer(
 
     def show(wx):
         if _invoke_show_header:
-            wx.show_asdf_header(False, False)
+            wx.header(False, False)
 
     if _use_weldx_file:
         write_kwargs = dict(all_array_storage="inline")

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -509,11 +509,8 @@ def get_highest_tag_version(
     if not tags:  # no match found
         return None
 
-    def _get_version(tag_name: str):
-        # we assume, that the version of the tag is separated by a right-most '-' char.
-        return Version(tag_name[tag_name.rfind("-") + 1 :])
-
-    tags.sort(key=_get_version)
+    # we assume, that the version of the tag is separated by a right-most '-' char.
+    tags.sort(key=lambda t: Version(t.rpartition("-")[-1]))
     base_tag = tags[-1].rpartition("-")[0]
     if not all(t.startswith(base_tag) for t in tags):
         raise ValueError(f"Found more than one base tag for {pattern=}.")

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Set
-from distutils.version import LooseVersion
 from io import BytesIO, TextIOBase
 from pathlib import Path
 from typing import Any, Hashable, MutableMapping, Union
@@ -15,6 +14,7 @@ from asdf.extension import Extension
 from asdf.tagged import TaggedDict
 from asdf.util import uri_match as asdf_uri_match
 from boltons.iterutils import get_path, remap
+from packaging.version import Version
 
 from weldx.asdf.constants import SCHEMA_PATH, WELDX_EXTENSION_URI
 from weldx.asdf.types import WeldxConverter
@@ -509,7 +509,11 @@ def get_highest_tag_version(
     if not tags:  # no match found
         return None
 
-    tags.sort(key=LooseVersion)
+    def _get_version(tag_name: str):
+        # we assume, that the version of the tag is separated by a right-most '-' char.
+        return Version(tag_name[tag_name.rfind("-") + 1 :])
+
+    tags.sort(key=_get_version)
     base_tag = tags[-1].rpartition("-")[0]
     if not all(t.startswith(base_tag) for t in tags):
         raise ValueError(f"Found more than one base tag for {pattern=}.")

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -314,7 +314,7 @@ class TestWeldXFile:
             kwargs = {"asdffile_kwargs": {"custom_schema": schema}}
         w = WeldxFile(buff, **kwargs)
         assert w.custom_schema == schema
-        w.show_asdf_header()  # check for exception safety.
+        w.header()  # check for exception safety.
 
     @staticmethod
     def test_custom_schema_resolve_path():
@@ -343,7 +343,7 @@ class TestWeldXFile:
         """Check displaying the header."""
         file = WeldxFile(tree={"sensor": "HKS_sensor"}, mode="rw")
         old_pos = file.file_handle.tell()
-        file.show_asdf_header()
+        file.header()
         after_pos = file.file_handle.tell()
         assert old_pos == after_pos
 
@@ -369,7 +369,7 @@ class TestWeldXFile:
         with WeldxFile(mode=mode) as fh:
             fh["x"] = large_array
             before = get_mem_info()
-            fh.show_asdf_header(use_widgets=False, _interactive=False)
+            fh.header(use_widgets=False, _interactive=False)
             after = get_mem_info()
             fh.write_to(fn)
 
@@ -386,7 +386,7 @@ class TestWeldXFile:
         """Ensure that the updated tree is displayed in show_header."""
         with WeldxFile(mode=mode) as fh:
             fh["wx_user"] = dict(test=True)
-            fh.show_asdf_header()
+            fh.header()
 
         out, _ = capsys.readouterr()
         assert "wx_user" in out
@@ -400,7 +400,7 @@ class TestWeldXFile:
     def test_show_header_params(use_widgets, interactive, capsys):
         """Check different inputs for show method."""
         fh = WeldxFile()
-        fh.show_asdf_header(use_widgets=use_widgets, _interactive=interactive)
+        fh.header(use_widgets=use_widgets, _interactive=interactive)
 
     def test_invalid_software_entry(self):
         """Invalid software entries should raise."""
@@ -433,7 +433,7 @@ class TestWeldXFile:
         wx_file = WeldxFile(fn, "rw", compression="input")
         size_rw = get_size_and_mtime(fn)
 
-        wx_file.show_asdf_header()
+        wx_file.header()
         size_show_hdr = get_size_and_mtime(fn)
         wx_file.close()
 


### PR DESCRIPTION
## Changes

* Refactored/deprecated WeldxFile.show_asdf_header to header.
* Use packaging.version instead of distutils.version (deprecated).

## Related Issues

Closes #688, #693

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [x] updated doc/
