### PR TITLE
use Python-3.10 in docs building, testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,7 @@ jobs:
         shell: bash -l {0}
         run: micromamba activate rtd
 
+      # TODO: this should be fixed upstream, try to remove it.
       - name: install dev version again
         # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
         # So the initial env creation lacks weldx, so we install it here.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,13 +52,6 @@ jobs:
         shell: bash -l {0}
         run: micromamba activate rtd
 
-      # TODO: this should be fixed upstream, try to remove it.
-      - name: install dev version again
-        # There is a bug in micromamba, which cd's out of the working-directory during the pip install of weldx.
-        # So the initial env creation lacks weldx, so we install it here.
-        shell: bash -l {0}
-        run: pwd && pip install -e .
-
       - name: conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,6 +44,7 @@ jobs:
       - name: pip installs
         run: |
           pip install wheel
+          pip install --pre "bottleneck==1.3.3rc13"
           pip install -e .[test]
 
       - name: run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,8 +44,7 @@ jobs:
       - name: pip installs
         run: |
           pip install wheel
-          pip install --pre "bottleneck==1.3.3rc13"
-          pip install -e .[test]
+          pip install --pre -e .[test]
 
       - name: run pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: ['3.8', '3.9']
+        py: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -51,7 +51,7 @@ jobs:
           pytest -n 2 --runslow --junit-xml pytest.xml
 
       - name: Upload Test Results
-        if: always() && (matrix.py == '3.9')
+        if: always() && (matrix.py == '3.10')
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,6 @@ jobs:
       - name: pip installs
         run: |
           pip install wheel
-          pip install --pre "bottleneck==1.3.3rc13"
           pip install -e .[test]
 
       - name: run pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,8 @@ jobs:
       - name: pip installs
         run: |
           pip install wheel
-          pip install --pre -e .[test]
+          pip install --pre "bottleneck==1.3.3rc13"
+          pip install -e .[test]
 
       - name: run pytest
         run: |

--- a/.github/workflows/pytest_asdf.yml
+++ b/.github/workflows/pytest_asdf.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all tags and branches
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: pip installs
         run: |
           pip install -e .[test]
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: pip installs
         run: |
           python -m pip install git+https://github.com/asdf-format/asdf.git

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,10 +35,12 @@ changes
 -  `LocalCoordinateSystem` and `CoordinateSystemManager` now support `pint.Quantity` as coordinates.
    Types without units are still supported but are deprecated. [:pull:`683`]
 
-- Renamed show_asdf_header of `WeldxFile` to `WeldxFile.header`. [:pull:`694`]
+-  Renamed show_asdf_header of `WeldxFile` to `WeldxFile.header`. [:pull:`694`]
 
-- `WeldxFile.custom_schema` now accepts an optional tuple with the first element being a schema to validate upon read,
-  the second upon writing the data. [:pull:`697`]
+-  `WeldxFile.custom_schema` now accepts an optional tuple with the first element being a schema to validate upon read,
+   the second upon writing the data. [:pull:`697`]
+
+-  Weldx now works with Python-3.10. [:pull:`696`]
 
 
 fixes

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.8,<3.11
 setup_requires =
     setuptools >=38.3.0
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,14 +38,14 @@ setup_requires =
     setuptools_scm
 install_requires =
     numpy >=1.20
-    asdf >=2.8.2
+    asdf >=2.8.2,<2.10
     pandas >=1.0
     xarray >=0.19
     scipy >=1.4,!=1.6.0,!=1.6.1
     sympy >=1.6
     pint >=0.18
     pint-xarray >=0.2.1
-    bottleneck >=1.3.3rc13
+    bottleneck >=1.3.3
     boltons
     bidict
     networkx >=2

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.8,<3.10
+python_requires = >=3.8
 setup_requires =
     setuptools >=38.3.0
     setuptools_scm
@@ -45,7 +45,7 @@ install_requires =
     sympy >=1.6
     pint >=0.18
     pint-xarray >=0.2.1
-    bottleneck >=1.3
+    bottleneck >=1.3.3rc13
     boltons
     bidict
     networkx >=2


### PR DESCRIPTION
## Changes

Since we now have a binary wheel for NumPy for this Python version, we transition to test against it.

UPDATE:
Bottleneck still causes trouble on 3.10, but we can leave this open until this is fixed.
