### PR TITLE
split read/write schema validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ changes
 
 - Renamed show_asdf_header of `WeldxFile` to `WeldxFile.header`. [:pull:`694`]
 
+- `WeldxFile.custom_schema` now accepts an optional tuple with the first element being a schema to validate upon read,
+  the second upon writing the data. [:pull:`697`]
+
 
 fixes
 =====

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ the creation and conversion of units and dimensions.
 **************
 
 The WelDX package can be installed using conda or mamba package manager
-from the :code:``conda-forge`` channel. These managers originate from
+from the `Conda-Forge channel <https://conda-forge.org/#about>`__. These managers originate from
 the freely available `Anaconda Python stack
 <https://docs.conda.io/en/latest/miniconda.html>`__. If you do not have
 Anaconda or Miniconda installed yet, we ask you to install

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -118,8 +118,21 @@ class WeldxFile(_ProtectedViewDict):
         If True, the changes to file will be written upon closing this. This is only
         relevant, if the file has been opened in write mode.
     custom_schema :
-        A path-like object to a custom schema which validates the tree. All schemas
-        provided by weldx can be given by name as well.
+        Either a path-like object to a custom schema which validates the tree
+        or a tuple of these objects. This tuple is allowed of lengths two and the first
+        element will be used to validate the file contents upon reading, the second
+        upon writing. For example:
+
+            (None, "A")
+
+        will not run validation upon reading, but for writing will use "A". Likewise
+
+            ("A", "B")
+
+        will use schema "A" to validate after reading, and "B" for writing again.
+
+        Note that all schemas provided by weldx can be given by name as well.
+
     software_history_entry :
         An optional dictionary which will be used to add history entries upon
         modification of the file. It has to provide the following keys:

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -26,7 +26,12 @@ from weldx.asdf.util import (
     get_yaml_header,
     view_tree,
 )
-from weldx.types import SupportsFileReadWrite, types_file_like, types_path_and_file_like
+from weldx.types import (
+    SupportsFileReadWrite,
+    types_file_like,
+    types_path_and_file_like,
+    types_path_like,
+)
 from weldx.util import (
     deprecated,
     inherit_docstrings,
@@ -191,15 +196,16 @@ class WeldxFile(_ProtectedViewDict):
 
     def __init__(
         self,
-        filename_or_file_like: Optional[
-            Union[str, pathlib.Path, types_file_like]
-        ] = None,
+        filename_or_file_like: Optional[Union[types_path_like, types_file_like]] = None,
         mode: str = "r",
         asdffile_kwargs: Mapping = None,
         write_kwargs: Mapping = None,
         tree: Mapping = None,
         sync: bool = True,
-        custom_schema: Union[str, pathlib.Path] = None,
+        custom_schema: Optional[
+            types_path_like,
+            tuple[None, types_path_like],
+        ] = None,
         software_history_entry: Mapping = None,
         compression: str = DEFAULT_ARRAY_COMPRESSION,
         copy_arrays: bool = DEFAULT_ARRAY_COPYING,
@@ -218,16 +224,9 @@ class WeldxFile(_ProtectedViewDict):
         self._write_kwargs = write_kwargs
         self._asdffile_kwargs = asdffile_kwargs
 
-        if custom_schema is not None:
-            _custom_schema_path = pathlib.Path(custom_schema)
-            if not _custom_schema_path.exists():
-                try:
-                    custom_schema = get_schema_path(custom_schema)
-                except ValueError:
-                    raise ValueError(
-                        f"provided custom_schema {custom_schema} " "does not exist."
-                    )
-            asdffile_kwargs["custom_schema"] = custom_schema
+        if "custom_schema" in asdffile_kwargs:
+            custom_schema = asdffile_kwargs.pop("custom_schema", None)
+        self._handle_custom_schema(custom_schema)
 
         if mode not in ("r", "rw"):
             raise ValueError(
@@ -247,7 +246,7 @@ class WeldxFile(_ProtectedViewDict):
             new_file_created = True
             self._in_memory = True
             self._close = False  # we want buffers to be usable later on.
-        elif isinstance(filename_or_file_like, (str, pathlib.Path)):
+        elif isinstance(filename_or_file_like, types_path_like.__args__):
             filename_or_file_like, new_file_created = self._handle_path(
                 filename_or_file_like, mode
             )
@@ -283,6 +282,8 @@ class WeldxFile(_ProtectedViewDict):
                 message="asdf.extensions plugin from package weldx.*",
             )  # we turn asdf warnings about loading the weldx extension into an error.
             if tree or new_file_created:
+                if self._schema_on_write:
+                    asdffile_kwargs["custom_schema"] = self._schema_on_write
                 asdf_file = self._write_tree(
                     filename_or_file_like,
                     tree,
@@ -293,6 +294,8 @@ class WeldxFile(_ProtectedViewDict):
                 if isinstance(filename_or_file_like, SupportsFileReadWrite):
                     filename_or_file_like.seek(0)
             else:
+                if self._schema_on_read:
+                    asdffile_kwargs["custom_schema"] = self._schema_on_read
                 asdf_file = open_asdf(
                     filename_or_file_like,
                     mode=self.mode,
@@ -302,6 +305,32 @@ class WeldxFile(_ProtectedViewDict):
 
         # initialize protected key interface.
         super().__init__(protected_keys=_PROTECTED_KEYS, data=self._asdf_handle.tree)
+
+    def _handle_custom_schema(self, custom_schema):
+        self._schema_on_read = self._schema_on_write = None
+
+        def resolve_schema(schema):
+            if schema is None:
+                return
+
+            _custom_schema_path = pathlib.Path(schema)
+            if not _custom_schema_path.exists():
+                try:
+                    schema = get_schema_path(schema)
+                except ValueError:
+                    raise ValueError(
+                        f"provided custom_schema '{schema}' " "does not exist."
+                    )
+            return schema
+
+        if isinstance(custom_schema, (list, tuple)):
+            if len(custom_schema) == 2:
+                self._schema_on_read = resolve_schema(custom_schema[0])
+                self._schema_on_write = resolve_schema(custom_schema[1])
+            else:
+                raise ValueError("custom_schema should be sequence of length two.")
+        elif isinstance(custom_schema, types_path_like.__args__):
+            self._schema_on_read = self._schema_on_write = resolve_schema(custom_schema)
 
     @contextmanager
     def _config_context(self, **kwargs):
@@ -330,6 +359,8 @@ class WeldxFile(_ProtectedViewDict):
             asdf_file = asdf.AsdfFile(tree=tree, **asdffile_kwargs)
             with self._config_context():
                 asdf_file.write_to(filename_or_path_like, **write_kwargs)
+            # Now set the file handle to the newly created AsdfFile instance.
+            # That way the handle will be closed by the asdf library later on.
             generic_file = generic_io.get_file(filename_or_path_like, mode="rw")
             asdf_file._fd = generic_file
         else:
@@ -683,9 +714,12 @@ class WeldxFile(_ProtectedViewDict):
         return self._asdf_handle["asdf_library"].copy()
 
     @property
-    def custom_schema(self) -> Optional[str]:
+    def custom_schema(self) -> Optional[str, tuple[Optional[str]]]:
         """Return schema used to validate the structure and types of the tree."""
-        return self._asdffile_kwargs.get("custom_schema", None)
+        if self._schema_on_read == self._schema_on_write:
+            return self._schema_on_read
+
+        return self._schema_on_read, self._schema_on_write
 
     @property
     # TODO: should we actually expose this? It allows advanced operations for adults.

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -14,7 +14,7 @@ from jsonschema import ValidationError
 
 from weldx.asdf.cli.welding_schema import single_pass_weld_example
 from weldx.asdf.file import _PROTECTED_KEYS, DEFAULT_ARRAY_INLINE_THRESHOLD, WeldxFile
-from weldx.asdf.util import get_schema_path
+from weldx.asdf.util import get_schema_path, write_buffer
 from weldx.constants import META_ATTR
 from weldx.types import SupportsFileReadWrite
 from weldx.util import WeldxDeprecationWarning, compare_nested
@@ -337,6 +337,79 @@ class TestWeldXFile:
         shutil.copy(get_schema_path(SINGLE_PASS_SCHEMA), ".")
         with pytest.raises(ValueError):
             WeldxFile(custom_schema="no")
+
+    @staticmethod
+    def _get_schema_file(arg, mismatch: bool) -> (str, np.ndarray):
+        data = np.arange(6)
+        if not arg or not isinstance(arg, (list, tuple)):
+            return None, data
+        result = [None, None]
+        shape = (1, -1)
+        schema = """
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://weldx.bam.de/weldx/schemas/debug/test_shape_validator-0.1.0"
+
+title: test
+type: object
+properties:
+  prop1:
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+    wx_shape: [{shape}]
+        """
+        d = pathlib.Path(tempfile.gettempdir())
+
+        if isinstance(arg, (list, tuple)):
+            a, b = arg
+            if a is not None:
+                fname = str(d / "a")
+                shape = [2, 3]
+                shape_s = ",".join(str(s) for s in shape)
+                with open(fname, "w+") as fh:
+                    fh.write(schema.format(shape=shape_s))
+                result[0] = fname
+            if b is not None:
+                fname = str(d / "b")
+                shape = [3, 2]
+                shape_s = ",".join(str(s) for s in shape)
+
+                with open(fname, "w+") as fh:
+                    fh.write(schema.format(shape=shape_s))
+                result[1] = fname
+
+            return result, data.reshape(shape) if not mismatch else data
+
+    @pytest.mark.parametrize(
+        ("custom_schema", "mismatch"),
+        (
+            (None, False),  # no validation (default)
+            ("A", False),  # validate against A on read and write (pre 0.6 behavior)
+            (("A", "B"), True),  # validate with A on read, validate with B on write
+            (("A", "B"), False),  # validate with A on read, validate with B on write
+            ((None, "A"), True),  # no validation on read, validate with B on write
+            ((None, "A"), False),  # no validation on read, validate with B on write
+            (("A", None), False),  # validate with A on read, no validation on write
+        ),
+    )
+    def test_custom_schema_modes(self, custom_schema, mismatch):
+        """Checks we can have separate read/write arguments for custom_schema."""
+        schema_resolved, data = self._get_schema_file(custom_schema, mismatch)
+        tree = {"prop1": data}
+
+        if mismatch:
+            if (
+                len(custom_schema) == 2
+                and custom_schema[0] == "A"
+                and custom_schema[1] == "B"
+            ):
+                buff = write_buffer(tree)
+            else:
+                buff = None
+            with pytest.raises(ValidationError):
+                WeldxFile(buff, tree=tree, mode="rw", custom_schema=schema_resolved)
+        else:
+            WeldxFile(tree=tree, mode="rw", custom_schema=schema_resolved)
 
     @staticmethod
     def test_show_header_file_pos_unchanged():


### PR DESCRIPTION
## Changes

WeldxFile now supports two custom_schema sub-arguments. The first argument will be used upon reading, the second upon writing. That way we can use separate schema for both operations. It turned out, that this is useful during schema development.

## Related Issues

Closes #690 

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [x] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
