### PR TITLE
[doc] fix SciPy intersphinx link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -313,7 +313,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "xarray": ("https://xarray.pydata.org/en/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
     "matplotlib": ("https://matplotlib.org", None),
     # "dask": ("https://docs.dask.org/en/latest", None),
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -99,5 +99,6 @@ py:obj mrp[i]
 # asdf
 py:class asdf.asdf.SerializationContext
 py:class iterable of asdf.extension.Compressor instances
+py:class iterable of asdf.extension.Compressor
 py:class See the class docstring for details on keyword
 py:class iterable of str


### PR DESCRIPTION
xref:
 https://github.com/scipy/scipy/issues/15545,
 https://github.com/apache/tvm/pull/10181

## Changes

Scipy has changed their doc structure to contain the release tag (there is no latest anymore as it seems).

## Checks

- [x] updated doc/
