### PR TITLE
treat `pint.UnitStrippedWarning` as error in pytest runs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,7 @@ norecursedirs = doc
 filterwarnings =
     ignore::DeprecationWarning:traittypes.*:
     ignore:Passing method to :FutureWarning:xarray.*:
+    error::pint.UnitStrippedWarning
 
 [isort]
 profile = black


### PR DESCRIPTION
## Changes

`pint.UnitStrippedWarning` will be raised as errors in our test suite

## Checks

- [x] updated tests

