### PR TITLE
allow string in `core/variable`, default tag sorting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,8 @@ ASDF
 
 -  update ``core/time_series`` schema to use ``time/time`` [:pull:`677`]
 
+-  update ``core/variable`` schema to allow single string as data [:pull:`707`]
+
 deprecations
 ============
 

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -105,10 +105,6 @@ class WeldxConverter(Converter, metaclass=WeldxConverterMeta):
         else:
             return cls.types[0].__qualname__
 
-    def select_tag(self, obj, tags, ctx):
-        """Set the tag for deserialization"""
-        return sorted(tags)[-1]
-
 
 def format_tag(tag_name, version=None, organization="weldx.bam.de", standard="weldx"):
     """

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -105,6 +105,10 @@ class WeldxConverter(Converter, metaclass=WeldxConverterMeta):
         else:
             return cls.types[0].__qualname__
 
+    def select_tag(self, obj, tags, ctx):
+        """Set the tag for deserialization"""
+        return sorted(tags)[-1]
+
 
 def format_tag(tag_name, version=None, organization="weldx.bam.de", standard="weldx"):
     """

--- a/weldx/manifests/weldx-0.1.1.yaml
+++ b/weldx/manifests/weldx-0.1.1.yaml
@@ -51,6 +51,8 @@ tags:
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/time_series-0.1.1
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/variable-0.1.0
+- tag_uri: asdf://weldx.bam.de/weldx/tags/core/variable-0.1.1
+  schema_uri: asdf://weldx.bam.de/weldx/schemas/core/variable-0.1.1
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.0
   schema_uri: asdf://weldx.bam.de/weldx/schemas/core/geometry/spatial_data-0.1.0
 - tag_uri: asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.1

--- a/weldx/schemas/weldx.bam.de/weldx/core/variable-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/variable-0.1.1.yaml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://weldx.bam.de/weldx/schemas/core/variable-0.1.1"
+
+title: |
+  Schema that describes a variable.
+description: |
+  This class is a slight modification of the corresponding NetCDF datamodel item.
+  (See https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_model.html)
+type: object
+properties:
+  name:
+    description: |
+      The variables name.
+    type: string
+  dimensions:
+    description: |
+      An array that contains the dimension names in the correct order (outer to inner).
+    type: array
+  dtype:
+    description: |
+      The arrays fundamental data type defined by a code of 3 characters (adapted from NumPy). For further information
+      see: https://numpy.org/doc/stable/reference/arrays.interface.html#arrays-interface
+    type: string
+  data:
+    description: |
+      An n-dimensional array that contains the data.
+    oneOf:
+      - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+      - type: number
+      - type: string
+  units:
+    description: |
+      Optional field describing the unit of the data.
+    tag: "asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"
+  attrs:
+    description: |
+      Additional attributes metadata associated with the variable.
+    type: object
+
+required: [name, dimensions, dtype, data]
+propertyOrder: [name, dimensions, dtype, units, data]
+flowStyle: block
+...

--- a/weldx/tags/core/common_types.py
+++ b/weldx/tags/core/common_types.py
@@ -51,6 +51,10 @@ class VariableConverter(WeldxConverter):
     ]
     types = [Variable]
 
+    def select_tag(self, obj, tags, ctx):
+        """Set highest available weldx tag for deserialization."""
+        return sorted(tags)[-1]
+
     @staticmethod
     def convert_time_dtypes(data: np.ndarray):
         """

--- a/weldx/tags/core/common_types.py
+++ b/weldx/tags/core/common_types.py
@@ -46,8 +46,9 @@ class Variable:
 class VariableConverter(WeldxConverter):
     """Serialization class for a Variable"""
 
-    name = "core/variable"
-    version = "0.1.0"
+    tags = [
+        "asdf://weldx.bam.de/weldx/tags/core/variable-0.1.*",
+    ]
     types = [Variable]
 
     @staticmethod

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -98,15 +98,23 @@ def get_xarray_example_data_array():
 
     """
     data = np.array([[0, 1], [2, 3]])
-    data = np.repeat(data[:, :, np.newaxis], 3, axis=-1)
+    data = np.repeat(data[..., np.newaxis], 3, axis=-1)
+    data = np.repeat(data[..., np.newaxis], 3, axis=-1)
 
     time_labels = ["2020-05-01", "2020-05-03"]
     d1 = np.array([-1, 1])
     d2 = pd.DatetimeIndex(time_labels)
     d3 = pd.timedelta_range("0s", "2s", freq="1s")
-    coords = {"d1": d1, "d2": d2, "d3": d3, "time_labels": (["d2"], time_labels)}
+    d4 = ["x", "y", "z"]
+    coords = {
+        "d1": d1,
+        "d2": d2,
+        "d3": d3,
+        "d4": d4,
+        "time_labels": (["d2"], time_labels),
+    }
 
-    dax = xr.DataArray(data=data, dims=["d1", "d2", "d3"], coords=coords)
+    dax = xr.DataArray(data=data, dims=["d1", "d2", "d3", "d4"], coords=coords)
 
     dax.attrs = {"answer": 42}
 
@@ -115,9 +123,10 @@ def get_xarray_example_data_array():
 
 @pytest.mark.parametrize("copy_arrays", [True, False])
 @pytest.mark.parametrize("lazy_load", [True, False])
-def test_xarray_data_array(copy_arrays, lazy_load):
+@pytest.mark.parametrize("select", [{}, {"d4": "z"}])
+def test_xarray_data_array(copy_arrays, lazy_load, select):
     """Test ASDF read/write of xarray.DataArray."""
-    dax = get_xarray_example_data_array()
+    dax = get_xarray_example_data_array().sel(**select)
     tree = {"dax": dax}
     dax_file = write_read_buffer(
         tree, open_kwargs={"copy_arrays": copy_arrays, "lazy_load": lazy_load}


### PR DESCRIPTION
## Changes
- update `core/variable` schema to allow single string values as data

## Related Issues
Before it was not possible to store `DataArray` / `Dataset` when selecting a singular dimension that was of type string (e.g. `coordinates.sel(c="z")`

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [x] update manifest file
