### PR TITLE
ignore matplotlib docs link warnings 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -275,7 +275,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "xarray": ("https://xarray.pydata.org/en/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
-    # "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org", None),
     # "dask": ("https://docs.dask.org/en/latest", None),
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "pint": ("https://pint.readthedocs.io/en/latest", None),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -275,7 +275,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
     "xarray": ("https://xarray.pydata.org/en/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/", None),
-    "matplotlib": ("https://matplotlib.org", None),
+    # "matplotlib": ("https://matplotlib.org", None),
     # "dask": ("https://docs.dask.org/en/latest", None),
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "pint": ("https://pint.readthedocs.io/en/latest", None),

--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -19,7 +19,9 @@ py:class npt.ArrayLike
 
 # matplotlib
 py:class matplotlib.axes.Axes
+py:obj matplotlib.axes.Axes
 py:class matplotlib.axes._axes.Axes
+py:class matplotlib.figure.Figure
 
 # pandas
 py:class pandas._libs.tslibs.timedeltas.Timedelta


### PR DESCRIPTION
## Changes
- ignore `matplotlib` link warnings in documentation


## Checks
- [x] updated doc/