### PR TITLE
set networkx<2.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,8 @@ dependencies
 
 -  add ``bidict`` dependency [:pull:`618`]
 
+-  set ``networkx <2.7`` for plotting compatibility (for now) [:pull:`714`]
+
 ********************
  0.5.2 (18.11.2021)
 ********************

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -280,7 +280,7 @@ intersphinx_mapping = {
     # "numba": ("https://numba.pydata.org/numba-doc/latest", None),
     "pint": ("https://pint.readthedocs.io/en/latest", None),
     "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
-    "asdf": ("https://asdf.readthedocs.io/en/latest/", None),
+    "asdf": ("https://asdf.readthedocs.io/en/2.9.2/", None),
     "networkx": ("https://networkx.org/documentation/stable/", None),
     "IPython": ("https://ipython.readthedocs.io/en/stable/", None),
     "k3d": ("https://k3d-jupyter.org/", None),

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     bottleneck >=1.3.3
     boltons
     bidict
-    networkx >=2
+    networkx >=2,<2.7
     matplotlib >=3
     fs
     ipywidgets


### PR DESCRIPTION
## Changes
- set `networkx<2.7`
- link `asdf` docs to version 2.9.2

CSM graph plotting error with networkx 2.7 see https://github.com/BAMWelDX/weldx/runs/5389199108?check_suite_focus=true#step:8:75


## Checks

- [x] updated CHANGELOG.rst

