### PR TITLE
allow asdf 2.10

### DIFF
--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -104,3 +104,4 @@ py:class iterable of asdf.extension.Compressor instances
 py:class iterable of asdf.extension.Compressor
 py:class See the class docstring for details on keyword
 py:class iterable of str
+py:class asdf_standard.resource.DirectoryResourceMapping

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     numpy >=1.20
-    asdf >=2.8.2,<2.10
+    asdf >=2.8.2
     pandas >=1.0
     xarray >=0.19
     scipy >=1.4,!=1.6.0,!=1.6.1


### PR DESCRIPTION
## Changes
- add asdf 2.10 back since the conda build seems to work now

