### PR TITLE
allow networkx >2.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,7 +92,7 @@ dependencies
 
 -  add ``bidict`` dependency [:pull:`618`]
 
--  set ``networkx <2.7`` for plotting compatibility (for now) [:pull:`714`]
+-  set ``networkx !=2.7`` for plotting compatibility (for now) [:pull:`714`, :pull:`722`]
 
 ********************
  0.5.2 (18.11.2021)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     bottleneck >=1.3.3
     boltons
     bidict
-    networkx >=2,<2.7
+    networkx >=2,!=2.7.0
     matplotlib >=3
     fs
     ipywidgets


### PR DESCRIPTION
## Changes
- our code should be good again after 2.7.1 release of networkx

## Related Issues
#714 

## Checks

- [x] updated CHANGELOG.rst
