### PR TITLE
reshape point data for `meshio` file export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,8 +42,7 @@ changes
 -  `WeldxFile.custom_schema` now accepts an optional tuple with the first element being a schema to validate upon read,
    the second upon writing the data. [:pull:`697`]
 
--  Weldx now works with Python-3.10. [:pull:`696`]
-
+-  Reshape `SpatialData` coordiantes to ``(-1, 3)`` before exporting with ``meshio`` for compatibility. [:pull:`723`]
 
 fixes
 =====
@@ -79,6 +78,8 @@ deprecations
 
 dependencies
 ============
+
+-  ``weldx`` now works with Python-3.10. [:pull:`696`]
 
 -  bump to ``asdf >=2.8.2`` [:pull:`668`]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,7 +42,7 @@ changes
 -  `WeldxFile.custom_schema` now accepts an optional tuple with the first element being a schema to validate upon read,
    the second upon writing the data. [:pull:`697`]
 
--  Reshape `SpatialData` coordiantes to ``(-1, 3)`` before exporting with ``meshio`` for compatibility. [:pull:`723`]
+-  Reshape `SpatialData` coordinates to ``(-1, 3)`` before exporting with ``meshio`` for compatibility. [:pull:`723`]
 
 fixes
 =====

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2935,7 +2935,8 @@ class SpatialData:
 
         """
         mesh = meshio.Mesh(
-            points=self.coordinates.data.reshape(-1,3), cells={"triangle": self.triangles}
+            points=self.coordinates.data.reshape(-1,3),
+            cells={"triangle": self.triangles},
         )
         mesh.write(file_name)
 

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2935,7 +2935,7 @@ class SpatialData:
 
         """
         mesh = meshio.Mesh(
-            points=self.coordinates.data, cells={"triangle": self.triangles}
+            points=self.coordinates.data.reshape(-1,3), cells={"triangle": self.triangles}
         )
         mesh.write(file_name)
 

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -2935,7 +2935,7 @@ class SpatialData:
 
         """
         mesh = meshio.Mesh(
-            points=self.coordinates.data.reshape(-1,3),
+            points=self.coordinates.data.reshape(-1, 3),
             cells={"triangle": self.triangles},
         )
         mesh.write(file_name)


### PR DESCRIPTION
## Changes
- This reshapes all point data to be in the shape `(n,3)` when exporting to other file formats using `meshio`.
Since file formats might not work with our 'profile based' dimensions like `(p,n,3)`this should be a safe way to export the pointcloud.


## Checks

- [x] updated CHANGELOG.rst
