### PR TITLE
fix docs build

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - ipywidgets
   # documentation
   - sphinx>=4.1.1
-  - jinja2
+  - jinja2=3.0
   - sphinxcontrib-napoleon
   - nbsphinx
   - sphinx-copybutton


### PR DESCRIPTION
## Changes
weekly build: https://github.com/BAMWelDX/weldx/runs/5715407058?check_suite_focus=true
```
nbsphinx.NotebookError: AttributeError in tutorials/measurement_example.ipynb:
module 'jinja2.utils' has no attribute 'escape'
```

## Checks
- [x] updated doc/

