### PR TITLE
set default tag sorting order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
           - mdformat-config
   # ----- Python formatting -----
   - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: v1
+    rev: v1.0
     hooks:
     - id: upgrade-type-hints
       args: [ '--futures=true' ]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,8 @@ ASDF
 
 -  update ``core/variable`` schema to allow single string as data [:pull:`707`]
 
+-  update the default sorting order of ``select_tag`` for ``WeldxConverter`` [:pull:`733`]
+
 deprecations
 ============
 

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -88,14 +88,17 @@ class WeldxConverterMeta(type(Converter)):
 class WeldxConverter(Converter, metaclass=WeldxConverterMeta):
     """Base class to inherit from for custom converter classes."""
 
-    tags: list[str] = []
-    types: list[Union[type, str]] = []
+    tags: tuple[str] = None  # note: this will be updated by WeldxConverterMeta.
+    types: tuple[Union[type, str]] = ()
 
     def to_yaml_tree(self, obj, tag: str, ctx: SerializationContext):
         raise NotImplementedError
 
     def from_yaml_tree(self, node: dict, tag: str, ctx: SerializationContext):
         raise NotImplementedError
+
+    def select_tag(self, obj, tags, ctx):
+        return sorted(tags)[-1]
 
     @classmethod
     def default_class_display_name(cls):

--- a/weldx/tags/core/data_array.py
+++ b/weldx/tags/core/data_array.py
@@ -12,8 +12,7 @@ from weldx.asdf.util import _get_instance_shape
 class XarrayDataArrayConverter(WeldxConverter):
     """Serialization class for xarray.DataArray."""
 
-    name = "core/data_array"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/data_array-0.1.*"]
     types = [DataArray]
 
     def to_yaml_tree(self, obj: DataArray, tag: str, ctx) -> dict:

--- a/weldx/tags/core/dataset.py
+++ b/weldx/tags/core/dataset.py
@@ -7,8 +7,7 @@ from weldx.asdf.types import WeldxConverter
 class XarrayDatasetConverter(WeldxConverter):
     """Serialization class for xarray.Dataset"""
 
-    name = "core/dataset"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/dataset-0.1.*"]
     types = [Dataset]
 
     def to_yaml_tree(self, obj: Dataset, tag: str, ctx) -> dict:

--- a/weldx/tags/core/file.py
+++ b/weldx/tags/core/file.py
@@ -139,8 +139,7 @@ class ExternalFile:
 class ExternalFileConverter(WeldxConverter):
     """Serialization class for `weldx.core.ExternalFile`."""
 
-    name = "core/file"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/file-0.1.*"]
     types = [ExternalFile]
 
     def to_yaml_tree(self, obj: ExternalFile, tag: str, ctx) -> dict:

--- a/weldx/tags/core/generic_series.py
+++ b/weldx/tags/core/generic_series.py
@@ -24,8 +24,7 @@ GenericSeriesFreeDimensionConverter = dataclass_serialization_class(
 class GenericSeriesConverter(WeldxConverter):
     """Serialization class for weldx.core.GenericSeries"""
 
-    name = "core/generic_series"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/generic_series-0.1.*"]
     types = [GenericSeries]
 
     def to_yaml_tree(self, obj: GenericSeries, tag: str, ctx) -> dict:

--- a/weldx/tags/core/graph.py
+++ b/weldx/tags/core/graph.py
@@ -21,8 +21,7 @@ class DiEdge:
 class DiEdgeConverter(WeldxConverter):
     """ASDF type for `DiEdge`."""
 
-    name = "core/graph/di_edge"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/graph/di_edge-0.1.*"]
     types = [DiEdge]
 
     def to_yaml_tree(self, obj: DiEdge, tag: str, ctx) -> dict:
@@ -49,8 +48,7 @@ class DiNode:
 class DiNodeConverter(WeldxConverter):
     """ASDF type for `DiNode`."""
 
-    name = "core/graph/di_node"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/graph/di_node-0.1.*"]
     types = [DiNode]
 
     def to_yaml_tree(self, obj: DiNode, tag: str, ctx) -> dict:
@@ -150,8 +148,7 @@ def build_graph(current_node: DiNode, graph: nx.DiGraph = None) -> nx.DiGraph:
 class DiGraphConverter(WeldxConverter):
     """Serialization class for `networkx.DiGraph`."""
 
-    name = "core/graph/di_graph"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/graph/di_graph-0.1.*"]
     types = [nx.DiGraph]
 
     def to_yaml_tree(self, obj: nx.DiGraph, tag: str, ctx) -> dict:

--- a/weldx/tags/core/mathematical_expression.py
+++ b/weldx/tags/core/mathematical_expression.py
@@ -13,8 +13,7 @@ __all__ = ["MathematicalExpression", "MathematicalExpressionConverter"]
 class MathematicalExpressionConverter(WeldxConverter):
     """Serialization class for sympy style math expressions."""
 
-    name = "core/mathematical_expression"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.*"]
     types = [MathematicalExpression]
 
     def to_yaml_tree(self, obj: MathematicalExpression, tag: str, ctx) -> dict:

--- a/weldx/tags/core/transformations/local_coordinate_system.py
+++ b/weldx/tags/core/transformations/local_coordinate_system.py
@@ -1,3 +1,4 @@
+from weldx.asdf.constants import WELDX_TAG_URI_BASE
 from weldx.asdf.types import WeldxConverter
 from weldx.core import TimeSeries
 from weldx.tags.core.common_types import Variable
@@ -7,8 +8,7 @@ from weldx.transformations import LocalCoordinateSystem
 class LocalCoordinateSystemConverter(WeldxConverter):
     """Serialization class for weldx.transformations.LocalCoordinateSystem"""
 
-    name = "core/transformations/local_coordinate_system"
-    version = "0.1.0"
+    tags = [WELDX_TAG_URI_BASE + "core/transformations/local_coordinate_system-0.1.*"]
     types = [LocalCoordinateSystem]
 
     def to_yaml_tree(self, obj: LocalCoordinateSystem, tag: str, ctx) -> dict:

--- a/weldx/tags/core/transformations/rotation.py
+++ b/weldx/tags/core/transformations/rotation.py
@@ -9,8 +9,7 @@ from weldx.transformations.rotation import ROT_META, WXRotation
 class WXRotationConverter(WeldxConverter):
     """Serialization class for the 'Scipy.Rotation' type"""
 
-    name = "core/transformations/rotation"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.*"]
     types = [Rotation, WXRotation]
 
     def to_yaml_tree(self, obj: Rotation, tag: str, ctx) -> dict:

--- a/weldx/tags/measurement/measurement_chain.py
+++ b/weldx/tags/measurement/measurement_chain.py
@@ -10,8 +10,7 @@ __all__ = [
 class MeasurementChainConverter(WeldxConverter):
     """Serialization class for measurement chains"""
 
-    name = "measurement/measurement_chain"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/measurement/measurement_chain-0.1.*"]
     types = [MeasurementChain]
 
     def to_yaml_tree(self, obj: MeasurementChain, tag: str, ctx) -> dict:

--- a/weldx/tags/time/datetimeindex.py
+++ b/weldx/tags/time/datetimeindex.py
@@ -12,8 +12,7 @@ __all__ = ["DatetimeIndexConverter"]
 class DatetimeIndexConverter(WeldxConverter):
     """A simple implementation of serializing pandas DatetimeIndex."""
 
-    name = "time/datetimeindex"
-    version = "0.1.*"
+    tags = ["asdf://weldx.bam.de/weldx/tags/time/datetimeindex-0.1.*"]
     types = [pd.DatetimeIndex]
 
     def to_yaml_tree(self, obj: pd.DatetimeIndex, tag: str, ctx) -> dict:

--- a/weldx/tags/time/time.py
+++ b/weldx/tags/time/time.py
@@ -7,8 +7,7 @@ __all__ = ["TimeConverter"]
 class TimeConverter(WeldxConverter):
     """A simple implementation of serializing a Time instance."""
 
-    name = "time/time"
-    version = "0.1.0"
+    tags = ["asdf://weldx.bam.de/weldx/tags/time/time-0.1.*"]
     types = [Time]
 
     def to_yaml_tree(self, obj: Time, tag: str, ctx) -> dict:

--- a/weldx/tags/time/timedeltaindex.py
+++ b/weldx/tags/time/timedeltaindex.py
@@ -12,8 +12,7 @@ __all__ = ["TimedeltaIndexConverter"]
 class TimedeltaIndexConverter(WeldxConverter):
     """A simple implementation of serializing pandas TimedeltaIndex."""
 
-    name = "time/timedeltaindex"
-    version = "0.1.*"
+    tags = ["asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.*"]
     types = [pd.TimedeltaIndex]
 
     def to_yaml_tree(self, obj: pd.TimedeltaIndex, tag: str, ctx) -> dict:

--- a/weldx/tags/units/pint_quantity.py
+++ b/weldx/tags/units/pint_quantity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pint
 from asdf.tagged import TaggedDict
 
+from weldx.asdf.constants import WELDX_TAG_URI_BASE
 from weldx.asdf.types import WeldxConverter
 from weldx.asdf.util import _get_instance_shape
 from weldx.constants import Q_, U_
@@ -35,6 +36,10 @@ class PintQuantityConverter(WeldxConverter):
         if tag.startswith("tag:stsci.edu:asdf"):  # asdf compat
             return Q_(node["value"], node["unit"])
         return Q_(node["value"], node["units"])
+
+    def select_tag(self, obj, tags, ctx):
+        tags = [tag for tag in tags if tag.startswith(WELDX_TAG_URI_BASE)]
+        return sorted(tags)[-1]
 
     @staticmethod
     def shape_from_tagged(node: TaggedDict) -> list[int]:


### PR DESCRIPTION
## Changes
- update the default sorting order of ``select_tag`` for ``WeldxConverter``
- use full tag naming schema in all explicit converters

## Checks

- [x] updated CHANGELOG.rst

