### PR TITLE
[RTD] use new post_checkout build phase to unshallow copy.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,9 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-  post_checkout:
-    - git fetch --unshallow
+  jobs:
+    post_checkout:
+      - git fetch --unshallow
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Changes

Get all commits and tags to have reliable information to derive the version number. We had some unreliable versioning on RTD before, whereas the latest tags were missing and due to that a dev version with a tons of commits had been shown.

## Related Issues

Closes #549 

## Checks

- [ ] updated CHANGELOG.rst
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
