### PR TITLE
custom `wx_unit` validation behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,7 +75,7 @@ ASDF
 
 -  update the default sorting order of ``select_tag`` for ``WeldxConverter`` [:pull:`733`]
 
--  add custom validation behavior to `wx_unit` [:pull:`739`]
+-  add custom validation behavior to ``wx_unit`` [:pull:`739`]
 
 deprecations
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,6 +75,8 @@ ASDF
 
 -  update the default sorting order of ``select_tag`` for ``WeldxConverter`` [:pull:`733`]
 
+-  add custom validation behavior to `wx_unit` [:pull:`739`]
+
 deprecations
 ============
 

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -8,6 +8,7 @@ from typing import Any, Hashable, MutableMapping, Union
 from warnings import warn
 
 import asdf
+import pint
 from asdf.asdf import SerializationContext
 from asdf.config import AsdfConfig, get_config
 from asdf.extension import Extension
@@ -18,6 +19,7 @@ from packaging.version import Version
 
 from weldx.asdf.constants import SCHEMA_PATH, WELDX_EXTENSION_URI
 from weldx.asdf.types import WeldxConverter
+from weldx.constants import U_, UNITS_KEY
 from weldx.types import (
     SupportsFileReadWrite,
     types_file_like,
@@ -541,6 +543,33 @@ def _get_instance_shape(
         converter = get_converter_for_tag(instance_dict._tag)
         if hasattr(converter, "shape_from_tagged"):
             return converter.shape_from_tagged(instance_dict)
+    return None
+
+
+def _get_instance_units(
+    instance_dict: Union[TaggedDict, dict[str, Any]]
+) -> Union[pint.Unit, None]:
+    """Get the units of an ASDF instance from its tagged dict form.
+
+    Parameters
+    ----------
+    instance_dict
+        The yaml node to evaluate.
+
+    Returns
+    -------
+    pint.Unit
+        The pint unit or `None` if no unit information is present.
+    """
+    if isinstance(instance_dict, (float, int)):  # test against [1] for scalar values
+        return U_.dimensionless
+    elif isinstance(instance_dict, Mapping) and UNITS_KEY in instance_dict:
+        return U_(str(instance_dict[UNITS_KEY]))  # catch TaggedString as str
+    elif isinstance(instance_dict, asdf.types.tagged.Tagged):
+        # try calling shape_from_tagged for custom types
+        converter = get_converter_for_tag(instance_dict._tag)
+        if hasattr(converter, "units_from_tagged"):
+            return converter.units_from_tagged(instance_dict)
     return None
 
 

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -568,7 +568,7 @@ def _get_instance_units(
     elif isinstance(instance_dict, Mapping) and UNITS_KEY in instance_dict:
         return U_(str(instance_dict[UNITS_KEY]))  # catch TaggedString as str
     elif isinstance(instance_dict, asdf.types.tagged.Tagged):
-        # try calling shape_from_tagged for custom types
+        # try calling units_from_tagged for custom types
         converter = get_converter_for_tag(instance_dict._tag)
         if hasattr(converter, "units_from_tagged"):
             return converter.units_from_tagged(instance_dict)

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -8,11 +8,13 @@ from typing import Any, Hashable, MutableMapping, Union
 from warnings import warn
 
 import asdf
+import numpy as np
 import pint
 from asdf.asdf import SerializationContext
 from asdf.config import AsdfConfig, get_config
 from asdf.extension import Extension
 from asdf.tagged import TaggedDict
+from asdf.tags.core.ndarray import NDArrayType
 from asdf.util import uri_match as asdf_uri_match
 from boltons.iterutils import get_path, remap
 from packaging.version import Version
@@ -561,7 +563,7 @@ def _get_instance_units(
     pint.Unit
         The pint unit or `None` if no unit information is present.
     """
-    if isinstance(instance_dict, (float, int)):  # test against [1] for scalar values
+    if isinstance(instance_dict, (float, int, np.ndarray, NDArrayType)):  # base types
         return U_.dimensionless
     elif isinstance(instance_dict, Mapping) and UNITS_KEY in instance_dict:
         return U_(str(instance_dict[UNITS_KEY]))  # catch TaggedString as str

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -96,13 +96,20 @@ def _unit_validator(
         position = instance
 
     units = _get_instance_units(instance)
-    valid = units.is_compatible_with(U_(expected_dimensionality))
-    if not valid:
+    if units is None:
         yield ValidationError(
             f"Error validating unit dimension for property '{position}'. "
             f"Expected unit of dimension '{expected_dimensionality}' "
-            f"but got unit '{units}'"
+            "but found no unit information"
         )
+    else:
+        valid = units.is_compatible_with(U_(expected_dimensionality))
+        if not valid:
+            yield ValidationError(
+                f"Error validating unit dimension for property '{position}'. "
+                f"Expected unit of dimension '{expected_dimensionality}' "
+                f"but got unit '{units}'"
+            )
 
 
 def _compare(_int, exp_string):

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -10,7 +10,7 @@ from asdf import ValidationError
 from asdf.schema import _type_to_tag
 
 from weldx.asdf.types import WxSyntaxError
-from weldx.asdf.util import _get_instance_shape, uri_match
+from weldx.asdf.util import _get_instance_shape, _get_instance_units, uri_match
 from weldx.constants import U_
 
 __all__ = ["wx_unit_validator", "wx_shape_validator", "wx_property_tag_validator"]
@@ -95,14 +95,13 @@ def _unit_validator(
     if not position:
         position = instance
 
-    unit = instance["units"]
-    unit = str(unit)  # catch TaggedString
-    valid = U_(unit).is_compatible_with(U_(expected_dimensionality))
+    units = _get_instance_units(instance)
+    valid = units.is_compatible_with(U_(expected_dimensionality))
     if not valid:
         yield ValidationError(
             f"Error validating unit dimension for property '{position}'. "
             f"Expected unit of dimension '{expected_dimensionality}' "
-            f"but got unit '{unit}'"
+            f"but got unit '{units}'"
         )
 
 

--- a/weldx/schemas/weldx.bam.de/weldx/debug/test_unit_validator-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/debug/test_unit_validator-0.1.0.yaml
@@ -56,6 +56,10 @@ properties:
     tag: "asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.*"
     wx_unit: "Δ°C"
 
+  dimensionless:
+    description: a basic numeric type without any units or dimensionless quantity
+    wx_unit: " "
+
 required: [length_prop, velocity_prop, current_prop, delta_prop]
 propertyOrder: [length_prop, velocity_prop, current_prop]
 flowStyle: block

--- a/weldx/tags/core/data_array.py
+++ b/weldx/tags/core/data_array.py
@@ -51,5 +51,5 @@ class XarrayDataArrayConverter(WeldxConverter):
 
     @staticmethod
     def units_from_tagged(node: TaggedDict) -> pint.Unit:
-        """Calculate the shape from static tagged tree instance."""
+        """Get the units information from static tagged tree instance."""
         return _get_instance_units(node["data"])

--- a/weldx/tags/core/data_array.py
+++ b/weldx/tags/core/data_array.py
@@ -1,12 +1,13 @@
 """Serialization for xarray.DataArray."""
 from __future__ import annotations
 
+import pint
 from asdf.tagged import TaggedDict
 from xarray import DataArray
 
 import weldx.tags.core.common_types as ct
 from weldx.asdf.types import WeldxConverter
-from weldx.asdf.util import _get_instance_shape
+from weldx.asdf.util import _get_instance_shape, _get_instance_units
 
 
 class XarrayDataArrayConverter(WeldxConverter):
@@ -47,3 +48,8 @@ class XarrayDataArrayConverter(WeldxConverter):
     def shape_from_tagged(node: TaggedDict) -> list[int]:
         """Calculate the shape from static tagged tree instance."""
         return _get_instance_shape(node["data"]["data"])
+
+    @staticmethod
+    def units_from_tagged(node: TaggedDict) -> pint.Unit:
+        """Calculate the shape from static tagged tree instance."""
+        return _get_instance_units(node["data"])

--- a/weldx/tags/debug/test_unit_validator.py
+++ b/weldx/tags/debug/test_unit_validator.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass, field
+from typing import Union
 
 import numpy as np
 import pint
+import xarray as xr
 
 from weldx.asdf.util import dataclass_serialization_class
 from weldx.constants import Q_
@@ -21,6 +23,7 @@ class UnitValidatorTestClass:
     )
     simple_prop: dict = field(default_factory=lambda: dict(value=float(3), units="m"))
     delta_prop: dict = Q_(100, "Δ°C")
+    dimensionless: Union[float, int, np.ndarray, pint.Quantity, xr.DataArray] = 3.14
 
 
 UnitValidatorTestClassConverter = dataclass_serialization_class(

--- a/weldx/tests/asdf_tests/test_asdf_validators.py
+++ b/weldx/tests/asdf_tests/test_asdf_validators.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from asdf import ValidationError
 
 from weldx.asdf.types import WxSyntaxError
@@ -179,6 +180,9 @@ def test_shape_validator_exceptions(test_input):
     [
         UnitValidatorTestClass(),
         UnitValidatorTestClass(length_prop=Q_(1, "inch")),
+        UnitValidatorTestClass(dimensionless=Q_(1, " ")),
+        UnitValidatorTestClass(dimensionless=np.ones(3)),
+        UnitValidatorTestClass(dimensionless=xr.DataArray(data=Q_(np.ones(3)))),
     ],
 )
 def test_unit_validator(test):
@@ -210,6 +214,12 @@ def test_unit_validator(test):
         ),
         UnitValidatorTestClass(
             simple_prop={"value": float(3), "units": "s"},  # wrong unit
+        ),
+        UnitValidatorTestClass(
+            dimensionless=Q_(1, "s"),  # wrong unit
+        ),
+        UnitValidatorTestClass(
+            dimensionless=xr.DataArray(data=np.ones(3)),  # xarray must be quantity
         ),
     ],
 )


### PR DESCRIPTION
## Changes
- add support for custom unit validation via `units_from_tagged` and `_get_instance_units`
- numeric base types (int, float, ndarray) validate against dimensionless
- `data_array` now directly supports validation with `wx_unit`
- `pd.Timedelta`, `pd.TimedeltaIndex` and timedelta-like `weldx.Time` will validate against `wx_unit: "s"`

## Related Issues

Closes #95 

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
