### PR TITLE
cache conda env in CI runs

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -38,7 +38,7 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ./devtools/conda.recipe/build_env.yml
-          cache-env: true
+          cache-downloads: true
 
       - name: activate build env
         shell: bash -l {0}

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -34,20 +34,11 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
-      - name: Cache conda
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if ./devtools/conda.recipe/build_env.yml has not changed
-          CACHE_NUMBER: 2
-        with:
-          path: ~/micromamba/pkgs
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./devtools/conda.recipe/build_env.yml') }}
-
       - name: Setup Conda Environment
         uses: mamba-org/provision-with-micromamba@v11
         with:
           environment-file: ./devtools/conda.recipe/build_env.yml
-          micromamba-version: 0.16.0
+          cache-env: true
 
       - name: activate build env
         shell: bash -l {0}

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
       - name: Setup Conda Environment
-        uses: mamba-org/provision-with-micromamba@v11
+        uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ./devtools/conda.recipe/build_env.yml
           cache-env: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,22 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache conda
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if ./environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: |
-            ~/conda_pkgs_dir
-            ~/.cache/pip
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('./doc/rtd_environment.yml', './setup.cfg') }}
-
       - name: Setup Conda Environment
-        uses: mamba-org/provision-with-micromamba@v11
+        uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ./doc/rtd_environment.yml
           environment-name: rtd
+          cache-env: true
 
       - name: activate build env
         shell: bash -l {0}

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -31,4 +31,4 @@ dependencies:
   # pip packages
   - pip
   - pip:
-    - -e ../
+    - ../


### PR DESCRIPTION
## Changes
cache conda env in CI runs

Apparently the micromamba action now has some caching functions built in https://github.com/mamba-org/provision-with-micromamba#example-with-download-caching