### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -20,6 +20,9 @@ on:
 
 jobs:
   conda:
+    defaults:
+      run:
+        shell: bash -l {0}
     if: |
       (github.event.pull_request.draft == false) ||
       (github.event_name == 'workflow_dispatch') ||
@@ -41,19 +44,15 @@ jobs:
           cache-downloads: true
 
       - name: activate build env
-        shell: bash -l {0}
         run: micromamba activate build_env
 
       - name: conda info
-        shell: bash -l {0}
         run: conda info
 
       - name: conda list
-        shell: bash -l {0}
         run: conda list
 
       - name: Build from local conda recipe
-        shell: bash -l {0}
         run: conda mambabuild .
 
   pypi:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,11 @@ on:
         required: true
         default: 'always'
 
+# execute commands with conda aware shell by default:
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   build:
     if: |
@@ -39,19 +44,15 @@ jobs:
           cache-env: true
 
       - name: activate build env
-        shell: bash -l {0}
         run: micromamba activate rtd
 
       - name: conda info
-        shell: bash -l {0}
         run: conda info
 
       - name: conda list
-        shell: bash -l {0}
         run: conda list
 
       - name: install weldx kernel
-        shell: bash -l {0}
         run: ipython kernel install --user --name=weldx
 
       - name: set notebook execution
@@ -59,7 +60,6 @@ jobs:
         run: echo "nbsphinx_execute=${{ github.event.inputs.nbsphinx_execute }}" >> $GITHUB_ENV
 
       - name: Build docs
-        shell: bash -l {0}
         run: sphinx-build -W -n -b html -d build/doctrees doc build/html --keep-going -j auto -D nbsphinx_execute=${{ env.nbsphinx_execute }}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,20 +30,24 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
-      - uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.py }}
 
-      - uses: actions/cache@v3
+      - uses: CagtayFabry/pydeps2env@main
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          channels: 'conda-forge defaults'
+          extras: 'test'
+          setup_requires: 'include'
+
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ./environment.yml
+          environment-name: demo
+          cache-env: true
+          extra-specs: |
+            python=${{ matrix.py }}
+            wheel
 
       - name: pip installs
         run: |
-          pip install wheel
           pip install -e .[test]
 
       - name: run pytest
@@ -91,29 +95,24 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
-      - uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.py }}
 
-      - uses: actions/cache@v3
-        if: startsWith(runner.os, 'macOS')
+      - uses: CagtayFabry/pydeps2env@main
         with:
-          path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          channels: 'conda-forge defaults'
+          extras: 'test'
+          setup_requires: 'include'
 
-      - uses: actions/cache@v3
-        if: startsWith(runner.os, 'Windows')
+      - uses: mamba-org/provision-with-micromamba@main
         with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          environment-file: ./environment.yml
+          environment-name: demo
+          cache-env: true
+          extra-specs: |
+            python=${{ matrix.py }}
+            wheel
 
       - name: pip installs
         run: |
-          pip install wheel
           pip install -e .[test]
 
       - name: setup matplotlib

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,6 +52,7 @@ jobs:
         run: micromamba activate weldx
 
       - name: pip installs
+        shell: bash -l {0}
         run: |
           python -m pip install .
 
@@ -122,6 +123,7 @@ jobs:
         run: micromamba activate weldx
 
       - name: pip installs
+        shell: bash -l {0}
         run: |
           python -m pip install .
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,11 +53,9 @@ jobs:
             pip
 
       - name: activate env
-        shell: bash -l {0}
         run: micromamba activate weldx
 
       - name: pip installs
-        shell: bash -l {0}
         run: |
           python -m pip install .
 
@@ -124,11 +122,9 @@ jobs:
             pip
 
       - name: activate env
-        shell: bash -l {0}
         run: micromamba activate weldx
 
       - name: pip installs
-        shell: bash -l {0}
         run: |
           python -m pip install .
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: pip installs
         run: |
-          pip install .
+          python -m pip install .
 
       - name: run pytest
         run: |
@@ -123,7 +123,7 @@ jobs:
 
       - name: pip installs
         run: |
-          pip install .
+          python -m pip install .
 
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,11 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+# execute commands with conda aware shell by default:
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   event_file:
     name: "Upload PR Event File"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -131,11 +131,9 @@ jobs:
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')
         run: |
-          mkdir $env:USERPROFILE\.matplotlib\
-          echo backend: Agg > $env:USERPROFILE\.matplotlib\matplotlibrc
-          python -c "import matplotlib as m; print(m.matplotlib_fname())"
-          python -c "import matplotlib as m; print(m.rc_params()['backend'])"
-        shell: pwsh
+          if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
+          echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
+        shell: cmd
 
       - name: run pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: pip installs
         run: |
-          python -m pip install .
+          python -m pip install -e .
 
       - name: run pytest
         run: |
@@ -126,7 +126,7 @@ jobs:
 
       - name: pip installs
         run: |
-          python -m pip install .
+          python -m pip install -e .
 
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')
@@ -135,7 +135,6 @@ jobs:
           echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
           python -c "import matplotlib as m; print(m.matplotlib_fname())"
           python -c "import matplotlib as m; print(m.rc_params()['backend'])"
-        shell: cmd
 
       - name: run pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -131,7 +131,7 @@ jobs:
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')
         run: |
-          if not exist $env:USERPROFILE\.matplotlib\ ( mkdir $env:USERPROFILE\.matplotlib\ )
+          mkdir $env:USERPROFILE\.matplotlib\
           echo backend: Agg > $env:USERPROFILE\.matplotlib\matplotlibrc
           python -c "import matplotlib as m; print(m.matplotlib_fname())"
           python -c "import matplotlib as m; print(m.rc_params()['backend'])"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,12 +40,16 @@ jobs:
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ./environment.yml
-          environment-name: demo
+          environment-name: weldx
           cache-env: true
           extra-specs: |
             python=${{ matrix.py }}
             wheel
             pip
+
+      - name: activate env
+        shell: bash -l {0}
+        run: micromamba activate weldx
 
       - name: pip installs
         run: |
@@ -106,12 +110,16 @@ jobs:
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: ./environment.yml
-          environment-name: demo
+          environment-name: weldx
           cache-env: true
           extra-specs: |
             python=${{ matrix.py }}
             wheel
             pip
+
+      - name: activate env
+        shell: bash -l {0}
+        run: micromamba activate weldx
 
       - name: pip installs
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -131,10 +131,11 @@ jobs:
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')
         run: |
-          if not exist %userprofile%\.matplotlib\ ( mkdir %userprofile%\.matplotlib\ )
-          echo backend: Agg > %userprofile%\.matplotlib\matplotlibrc
+          if not exist $env:USERPROFILE\.matplotlib\ ( mkdir $env:USERPROFILE\.matplotlib\ )
+          echo backend: Agg > $env:USERPROFILE\.matplotlib\matplotlibrc
           python -c "import matplotlib as m; print(m.matplotlib_fname())"
           python -c "import matplotlib as m; print(m.rc_params()['backend'])"
+        shell: pwsh
 
       - name: run pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,10 +45,11 @@ jobs:
           extra-specs: |
             python=${{ matrix.py }}
             wheel
+            pip
 
       - name: pip installs
         run: |
-          pip install -e .[test]
+          pip install .
 
       - name: run pytest
         run: |
@@ -90,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        py: ['3.8']
+        py: ['3.9']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -110,10 +111,11 @@ jobs:
           extra-specs: |
             python=${{ matrix.py }}
             wheel
+            pip
 
       - name: pip installs
         run: |
-          pip install -e .[test]
+          pip install .
 
       - name: setup matplotlib
         if: startsWith(runner.os, 'Windows')


### PR DESCRIPTION
Since the micromamba caching seems to work pretty well I wanted to try it out with our pytest jobs as well.
I wrote a small GH action [pydeps2env](https://github.com/CagtayFabry/pydeps2env) that creates a conda `environment.yml` from the `setup.cfg` so we don't have to keep the dependencies in two files.

The speedups with `ubuntu` vs pip installs (incl. cache) look really good, the whole env setup now only takes 26s ([was 1 minute before](https://github.com/BAMWelDX/weldx/actions/runs/2218372175))

`macos` is down to 51 s from 150 s for caching + install (but the cache was slightly outdated)

## Changes
- use mamba + [pydeps2env](https://github.com/CagtayFabry/pydeps2env) in pytest jobs
- use default shell command in conda jobs

