### PR TITLE
Revert "set networkx<=2.8.0"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ fixes
 dependencies
 ============
 
--  Weldx now (optionally) requires weldx_widgets to visualize coordinate systems/manager [:pull:`749`].
+-  ``weldx`` now (optionally) requires ``weldx_widgets`` to visualize coordinate systems/manager [:pull:`749`].
 -  NumPy is not required as a build time dependency anymore, as Bottleneck now provides binaries on PyPI [:pull:`749`].
 
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,9 +23,8 @@ fixes
 dependencies
 ============
 
--  ``weldx`` now (optionally) requires ``weldx_widgets`` to visualize coordinate systems/manager [:pull:`749`].
+-  Weldx now (optionally) requires weldx_widgets to visualize coordinate systems/manager [:pull:`749`].
 -  NumPy is not required as a build time dependency anymore, as Bottleneck now provides binaries on PyPI [:pull:`749`].
--  Set ``networkx<=2.8.0`` to allow Python deepcopy of `CoordinateSystemManager` [:pull:`761`].
 
 ********************
  0.6.0 (29.04.2022)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     bottleneck >=1.3.3
     boltons
     bidict
-    networkx >=2,!=2.7.0
+    networkx >=2,!=2.7.0,!=2.8.1
     fs
     meshio
     psutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     bottleneck >=1.3.3
     boltons
     bidict
-    networkx >=2,!=2.7.0,<=2.8.0
+    networkx >=2,!=2.7.0
     fs
     meshio
     psutil


### PR DESCRIPTION
Reverts BAMWelDX/weldx#761

xref: https://github.com/networkx/networkx/issues/5655

networkx-2.8.2 just got released, so we should pin like ..., !=2.8.1