### PR TITLE
[doc] fix pattern for extlinks, use Sphinx-bundled (up2date) napoleon

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,7 @@ extensions = [
 # allow easy Issue/PR links
 extlinks = {
     "issue": ("https://github.com/BAMWelDX/weldx/issues/%s", "GH %s"),
-    "pull": ("https://github.com/BAMWelDX/weldx/pull/%s", "PR %S"),
+    "pull": ("https://github.com/BAMWelDX/weldx/pull/%s", "PR %s"),
 }
 
 # autosummary --------------------------------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,7 +110,7 @@ pygments_style = "sphinx"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinxcontrib.napoleon",
+    "sphinx.ext.napoleon",
     "nbsphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -124,8 +124,8 @@ extensions = [
 
 # allow easy Issue/PR links
 extlinks = {
-    "issue": ("https://github.com/BAMWelDX/weldx/issues/%s", "GH"),
-    "pull": ("https://github.com/BAMWelDX/weldx/pull/%s", "PR"),
+    "issue": ("https://github.com/BAMWelDX/weldx/issues/%s", "GH %s"),
+    "pull": ("https://github.com/BAMWelDX/weldx/pull/%s", "PR %S"),
 }
 
 # autosummary --------------------------------------------------------------------------

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -20,7 +20,6 @@ dependencies:
   # documentation
   - sphinx>=4.1.1
   - jinja2=3.0
-  - sphinxcontrib-napoleon
   - nbsphinx
   - sphinx-copybutton
   - pydata-sphinx-theme

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -387,7 +387,7 @@ class WeldxFile(_ProtectedViewDict):
 
     @property
     def mode(self) -> str:
-        """File operation mode: reading or reading/writing mode, one of "r" or "rw"."""
+        """File operation mode, reading or reading/writing mode, one of "r" or "rw"."""
         return self._mode
 
     @property

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import copy
-import inspect
 import io
 import pathlib
 import warnings
@@ -282,8 +281,7 @@ class WeldxFile(_ProtectedViewDict):
             # the user passed a raw file handle, its their responsibility to close it.
             self._close = False
         else:
-            a = inspect.get_annotations(WeldxFile.__init__)
-            _supported = a["filename_or_file_like"]
+            _supported = WeldxFile.__init__.__annotations__["filename_or_file_like"]
             raise ValueError(
                 f"Unsupported input type '{type(filename_or_file_like)}'."
                 f" Should be one of {_supported}."

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import io
 import pathlib
 import warnings
@@ -281,7 +282,8 @@ class WeldxFile(_ProtectedViewDict):
             # the user passed a raw file handle, its their responsibility to close it.
             self._close = False
         else:
-            _supported = WeldxFile.__init__.__annotations__["filename_or_file_like"]
+            a = inspect.get_annotations(WeldxFile.__init__)
+            _supported = a["filename_or_file_like"]
             raise ValueError(
                 f"Unsupported input type '{type(filename_or_file_like)}'."
                 f" Should be one of {_supported}."
@@ -387,7 +389,9 @@ class WeldxFile(_ProtectedViewDict):
 
     @property
     def mode(self) -> str:
-        """File operation mode, reading or reading/writing mode, one of "r" or "rw"."""
+        """File operation mode.
+
+        This is either reading or reading/writing mode, one of "r" or "rw"."""
         return self._mode
 
     @property


### PR DESCRIPTION
## Changes

- Title elements in ext_links require a template %s. The recently released Sphinx version triggered a warning about it.
- Napoleon used to be loaded as sphinxcontrib.napoleon; However sphinx.ext.napoleon is more recent.


## Checks

- [x] updated doc/
