### PR TITLE
Fix documentation build failure

### DIFF
--- a/doc/nitpick_ignore
+++ b/doc/nitpick_ignore
@@ -13,8 +13,8 @@ py:class weldx.asdf.types.WeldxConverter
 py:data collections.abc.Callable
 
 # numpy typing
-py:class numpy.typing._array_like._SupportsArray
-py:class numpy.typing._nested_sequence._NestedSequence
+py:class numpy._typing._array_like._SupportsArray
+py:class numpy._typing._nested_sequence._NestedSequence
 py:class npt.ArrayLike
 
 # matplotlib


### PR DESCRIPTION
## Changes

The documentation build [is currently failing](https://github.com/BAMWelDX/weldx/runs/7191565239?check_suite_focus=true) due to some numpy-related warnings. Seems like they moved some types we ignored previously in the `nitpick_ignore`.


## Checks

- [x] ~~updated CHANGELOG.rst~~
- [x] ~~updated tests~~
- [x] ~~updated doc/~~
- [x] ~~update example/tutorial notebooks~~
- [x] ~~update manifest file~~
