### PR TITLE
Fix k3d in RTD documentation

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - bottleneck>=1.3
   # notebook execution
   - ipykernel
-  - ipywidgets
+  - ipywidgets<8
   - weldx_widgets >=0.2.1
   # documentation
   - sphinx>=4.1.1


### PR DESCRIPTION
## Changes

k3d plots are currently broken. Have a look at the plots [here](https://weldx.readthedocs.io/en/latest/tutorials/transformations_02_coordinate_system_manager.html)


## Checks

- [ ] ~~updated CHANGELOG.rst~~
- [ ] ~~updated tests~~
- [ ] updated doc/
- [ ] ~~update example/tutorial notebooks~~
- [ ] ~~update manifest file~~
