### PR TITLE
Generated jupyter notebook cell ids (required for jupyter notebook format 4.5+)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -281,7 +281,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "xarray": ("https://xarray.pydata.org/en/stable", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/objects.inv", None),
     "scipy": (f"https://docs.scipy.org/doc/scipy-{_scipy_version}/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
     # "dask": ("https://docs.dask.org/en/latest", None),

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -20,7 +20,6 @@ dependencies:
   # documentation
   - sphinx>=4.1.1
   - jinja2=3.0
-  - nbformat<5.5.0 # pending https://github.com/BAMWelDX/weldx/actions/runs/3125636543/jobs/5070212013
   - nbsphinx
   - sphinx-copybutton
   - pydata-sphinx-theme

--- a/tutorials/01_01_introduction.ipynb
+++ b/tutorials/01_01_introduction.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "4182dcd6",
    "metadata": {},
    "source": [
     "# Introduction / Opening WelDX Files\n",
@@ -43,6 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ae81c166",
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -63,6 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "36c514ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,6 +74,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e3ec375b",
    "metadata": {},
    "source": [
     "WelDX files usually have the extension `.weldx` or `.wx`, but any other is also possible as long as the content is valid.\n",
@@ -81,6 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "630bd97c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,6 +94,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0d183782",
    "metadata": {},
    "source": [
     "### Inspecting the file content in a Jupyter session\n",
@@ -104,6 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d7ac29d4",
    "metadata": {
     "tags": []
    },
@@ -114,6 +121,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "988d0409",
    "metadata": {},
    "source": [
     "### Inspecting the File content with pure Python\n",
@@ -129,6 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9863459a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,6 +146,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "85eb6e37",
    "metadata": {},
    "source": [
     "The `info` method lists the internal file structure converted to python objects.\n",
@@ -147,6 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b5d960ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,6 +167,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "84a697ce",
    "metadata": {},
    "source": [
     "The output confirms that the object we got is truly of type `VGroove`.\n",
@@ -164,6 +176,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "078d2b27",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/tutorials/01_02_time_dependent_data.ipynb
+++ b/tutorials/01_02_time_dependent_data.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "6d747389",
    "metadata": {},
    "source": [
     "# Time dependent data / Welding current and voltage\n",
@@ -22,6 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "edeb5c02",
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -41,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1cfb7522",
    "metadata": {
     "tags": []
    },
@@ -58,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a1f650a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,6 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ea678360",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,6 +82,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a529651a",
    "metadata": {},
    "source": [
     "As we can see in the list, there are the top level items `welding_current` and `welding_voltage`.\n",
@@ -86,6 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1af19636",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,6 +101,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0d0e04ec",
    "metadata": {},
    "source": [
     "The object we extracted is of type `TimeSeries` as can be seen in the `info` output.\n",
@@ -106,6 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f32813e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,6 +123,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f45b4d28",
    "metadata": {},
    "source": [
     "The `plot` method is an easy and convenient way to quickly visualize a `TimeSeries`.\n",
@@ -131,6 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d00a332f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +150,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "26aa4691",
    "metadata": {},
    "source": [
     "Now let's plot the welding voltage. \n",
@@ -150,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca2ce187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,6 +172,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "19eb4fdc",
    "metadata": {},
    "source": [
     "## Accessing the data \n",
@@ -171,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4a72e1a2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,6 +194,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac8e05a3",
    "metadata": {},
    "source": [
     "From the returned value we see that the data indeed only consists of a single dimension.\n",
@@ -191,6 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e4a4c1a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,6 +216,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b8bdbd95",
    "metadata": {},
    "source": [
     "As one might expect, the unit of the current is amperes, but it might also have been stored in milliamperes.\n",
@@ -210,6 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "22934d29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,6 +237,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fb036ded",
    "metadata": {},
    "source": [
     "A `pint.Quantity` is a thin wrapper around a multi-dimensional array that attaches units to the contained data.\n",
@@ -231,6 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "aab663a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,6 +260,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e09e9b4",
    "metadata": {},
    "source": [
     "Xarray is a powerful tool that makes working with multi-dimensional arrays easier.\n",
@@ -252,6 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dc20a262",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,6 +283,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fcb79231",
    "metadata": {},
    "source": [
     "For xarray use `.data` to get the data as `pint.Quantity` and then `.magnitude` or `.m` to receive a `numpy.ndarray`:"
@@ -268,6 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "73cacaae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,6 +301,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e25735b8",
    "metadata": {},
    "source": [
     "## Data processing examples\n",
@@ -288,6 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9c2a36f3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b28100f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca769f05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,6 +343,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "43f99b83",
    "metadata": {},
    "source": [
     "If you exchange `.data` with `.data_array`, you will get the same results just as `xarray.DataArray`.\n",
@@ -330,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5972af2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,6 +372,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9cb722fd",
    "metadata": {},
    "source": [
     "The parameter `datetime_unit` specifies the unit of the time coordinates during the integration.\n",
@@ -353,6 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f4de64ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,6 +396,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eb8f4d78",
    "metadata": {},
    "source": [
     "What remains now is to divide the result by the process duration.\n",
@@ -376,6 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "612ac8a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,6 +420,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "faeb7055",
    "metadata": {},
    "source": [
     "We can further simplify this by convert the units manually to Watt with `.to` or `.ito`.\n",
@@ -394,6 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "05f66239",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,6 +440,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3f41c72f",
    "metadata": {},
    "source": [
     "If you prefer compact numbers, you can use `.to_compact`:"
@@ -411,6 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4d6dadbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,6 +458,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a6b8cbec",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/tutorials/01_03_geometry.ipynb
+++ b/tutorials/01_03_geometry.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "560e37d3",
    "metadata": {
     "tags": []
    },
@@ -24,6 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d093c5f3",
    "metadata": {
     "collapsed": false,
     "jupyter": {
@@ -43,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f70ce1c3",
    "metadata": {
     "tags": []
    },
@@ -59,6 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53db4790",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,6 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c17c9384",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,6 +83,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "67f00449",
    "metadata": {},
    "source": [
     "The workpiece data of this particular file consists of two parts:\n",
@@ -103,6 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "86a372ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +119,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "eb8569db",
    "metadata": {},
    "source": [
     "Apart from the visual representation, the plot also contains all relevant information like the groove's area and the ISO 9692-1 parameters.\n",
@@ -128,6 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "891f6e00",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,6 +146,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4934eff7",
    "metadata": {},
    "source": [
     "We can plot the content of a `Profile` the same way as we did before with the groove:"
@@ -145,6 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3e228db8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,6 +164,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9e6e106",
    "metadata": {},
    "source": [
     "The only difference here is that we don't get the additional, norm-related information."
@@ -160,6 +172,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "be0ece42",
    "metadata": {},
    "source": [
     "## 3d plot (matplotlib)\n",
@@ -172,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "af4dbfd5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,6 +197,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "01bab142",
    "metadata": {},
    "source": [
     "Now all that remains, you might have guessed it, is to call the plot method:\n",
@@ -193,6 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f3dfccb2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,6 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "65191790",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,6 +227,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b709733d",
    "metadata": {},
    "source": [
     "By default, the `plot` method shows us the triangulatad data.\n",
@@ -220,6 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f4582e66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +247,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8b1138de",
    "metadata": {},
    "source": [
     "The density of the triangle mesh or the point cloud can be controlled py the parameters `profile_raster_width` and `trace_raster_width`.\n",
@@ -240,6 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6845d5a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,6 +273,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "23a20417",
    "metadata": {},
    "source": [
     "As you can see, we now got only 3 densely rendered profiles.\n",
@@ -267,6 +289,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "80b188c8",
    "metadata": {},
    "source": [
     "## 3d plot (k3d)\n",
@@ -284,6 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "44309020",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,6 +316,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "439602f5",
    "metadata": {},
    "source": [
     "Now we got a nice 3d rendering of the geometry with a closed surface that we shift and turn as we like.\n",
@@ -304,6 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "11aa5d7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,6 +338,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fd006d4d",
    "metadata": {},
    "source": [
     "Now lets plot the geometry again:"
@@ -320,6 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e871f6d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,6 +356,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1193aded",
    "metadata": {},
    "source": [
     "## Export 3d geometry into a CAD file\n",
@@ -340,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5ab72220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,6 +380,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ca3ff56",
    "metadata": {},
    "source": [
     "The parameters `profile_raster_width` and `trace_raster_width` do have the exact same effect as in the `plot` method described before."
@@ -357,6 +388,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b9d7cd9c",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -377,6 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ab3b4f72",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/tutorials/01_04_coordinate_systems.ipynb
+++ b/tutorials/01_04_coordinate_systems.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c17221d8",
    "metadata": {},
    "source": [
     "# Coordinate Systems\n",
@@ -21,6 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c8c641f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,6 +35,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "54b9a3aa",
    "metadata": {},
    "source": [
     "## Dependency graph\n",
@@ -48,6 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c814abb4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,6 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ad43ed6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,6 +72,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bac36c1a",
    "metadata": {},
    "source": [
     "Examining the `info` output, we find that the object we are looking for is stored under the key `coordinate_systems`.\n",
@@ -76,6 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0b7a2248",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cfa89eed",
    "metadata": {},
    "source": [
     "As previously mentioned, the CSM is based on a tree structure.\n",
@@ -95,6 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "63908e4c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +112,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06d943ec",
    "metadata": {},
    "source": [
     "> HINT: In a jupyter session it is sufficient to just type the variable name at the end of a cell (here `csm`). \n",
@@ -127,6 +137,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4cadc45c",
    "metadata": {},
    "source": [
     "## Default 3d plot and time interpolation\n",
@@ -148,6 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "89fe935a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,6 +168,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "26e9474d",
    "metadata": {},
    "source": [
     "The `time_union` method collects every time value of all the time dependent coordinate systems of the CSM and merges them into a `Time` object.\n",
@@ -169,6 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fe1451ec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,6 +191,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c81b609c",
    "metadata": {},
    "source": [
     "We pass the resampled time object to the `interp_time` method of the CSM.\n",
@@ -186,6 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fd9618a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,6 +210,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4769e26b",
    "metadata": {},
    "source": [
     "Now we can call `plot` of the interpolated CSM without having to worry, that the calculation takes several minutes to create the plot.\n",
@@ -204,6 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "298313d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,6 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7436b3ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,6 +241,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fed4b332",
    "metadata": {},
    "source": [
     "The plot shows us the locations of all coordinate systems in 3d space.\n",
@@ -236,6 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "63500721",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,6 +265,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "030c509a",
    "metadata": {},
    "source": [
     "By checking the coordinate $x=0$, $y=0$, $z=0$ in the plot, you can derive that all data is plotted in the `user_frame` coordinate system.\n",
@@ -256,6 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "354bd20c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +291,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "68506636",
    "metadata": {},
    "source": [
     "Now the `user_frame` has suddenly become time dependent, and the flange remains static.\n",
@@ -279,6 +303,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c6d1956",
    "metadata": {},
    "source": [
     "## Interactive 3d plots with k3d\n",
@@ -298,6 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "495bcf86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +332,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "99954600",
    "metadata": {},
    "source": [
     "The first, most obvious thing you will notice is that the 3d scan of the geometry is now visualized because we didn't disable it anymore.\n",
@@ -324,6 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1b0a48e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,6 +365,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dc9b8023",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -355,6 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "474c6a1e",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/tutorials/generic_series.ipynb
+++ b/tutorials/generic_series.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "dc0eaceb",
    "metadata": {},
    "source": [
     "# `GenericSeries` Tutorial\n",
@@ -19,6 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a53fb427",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d8389049",
    "metadata": {},
    "source": [
     "For this tutorial, we will also need to import the following packages and classes:"
@@ -35,6 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e4ab6db2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,6 +52,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "865b19c3",
    "metadata": {},
    "source": [
     "## Terminology\n",
@@ -121,6 +126,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3fa2be44",
    "metadata": {},
    "source": [
     "## Discrete data\n",
@@ -140,6 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a5687692",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,6 +160,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fa70702d",
    "metadata": {},
    "source": [
     "We also know the coordinates of the data in `x` and `t`:"
@@ -161,6 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d75535bc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,6 +179,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ab23c771",
    "metadata": {},
    "source": [
     "Here is a quick plot of our temperature data:"
@@ -178,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e79e8109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,6 +198,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "72b281c8",
    "metadata": {},
    "source": [
     "Now we can create our `GenericSeries` as follows:"
@@ -195,6 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c6a686a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,6 +219,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b6c10c1c",
    "metadata": {},
    "source": [
     "The first argument is the raw data.\n",
@@ -218,6 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ad248f41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,6 +241,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "78bd07fd",
    "metadata": {},
    "source": [
     "If you are already familiar with the `xarray` python package, you might have noticed the similarities between the construction of a `GenericSeries` and an `xarray.DataArray`.\n",
@@ -234,6 +250,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "077d637c",
    "metadata": {},
    "source": [
     "## Evaluation/Interpolation\n",
@@ -247,6 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "91392645",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,6 +273,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3adfff4c",
    "metadata": {},
    "source": [
     "It is not necessary to provide coordinates for all dimensions.\n",
@@ -264,6 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9ded7e6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,6 +292,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fdcbe3ae",
    "metadata": {},
    "source": [
     "Of course, we can also evaluate multiple coordinate values for each dimension:"
@@ -280,6 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "55b054fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,6 +310,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d8407f18",
    "metadata": {},
    "source": [
     "You may have noticed that we exclusively used coordinate values that do not match the coordinates we initially provided to the `GenericSeries`.\n",
@@ -299,6 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c795143b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,6 +331,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a6cc1a37",
    "metadata": {},
    "source": [
     "In case the provided interpolation coordinates exceed the coordinate range of the series, the corresponding result value will be set to the closest boundary value.\n",
@@ -317,6 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0cced1fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,6 +357,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "71638a0f",
    "metadata": {},
    "source": [
     "As one might expect the linearly interpolated data is the mean value of both curves since $t=15s$ lies directly in the middle between $t=10s$ and $t=20s$.\n",
@@ -341,6 +368,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c125a374",
    "metadata": {},
    "source": [
     "## Using Expressions\n",
@@ -367,6 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c1708ad4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,6 +404,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8e8701e7",
    "metadata": {},
    "source": [
     "The syntax is pretty close to python code, except that it is enclosed inside of a string.\n",
@@ -386,6 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "af9a9c78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,6 +425,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e8d32047",
    "metadata": {},
    "source": [
     "We have now created a `GenericSeries` based on an expression.\n",
@@ -404,6 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c445e023",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,6 +445,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2df21aa2",
    "metadata": {},
    "source": [
     "The first item of the output is the expression we entered, but there are also the fields `Parameters`, `Dimensions`, and `Units`.\n",
@@ -426,6 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "086d0663",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,6 +472,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ebd82a5e",
    "metadata": {},
    "source": [
     "The result is a new `GenericSeries` with discrete values at the coordinates we provided.\n",
@@ -446,6 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53933b80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,6 +496,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4462d8c7",
    "metadata": {},
    "source": [
     "### Adding parameters\n",
@@ -471,6 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59af18af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,6 +518,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ba1da5c9",
    "metadata": {},
    "source": [
     "So far, there is nothing that distinct `s` and `o` from `x` and `t`.\n",
@@ -491,6 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "19bb082b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,6 +544,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce35e742",
    "metadata": {},
    "source": [
     "As you can see, `s` and `o` now appear in the `Parameters` section together with the values we assigned to them while `t` and `x` are still variables.\n",
@@ -512,6 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c3489b70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,6 +569,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "66bfdacf",
    "metadata": {},
    "source": [
     "### Adding units"
@@ -533,6 +577,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02d59b8f",
    "metadata": {},
    "source": [
     "The final piece we are missing in resembling the discrete data as expression are units.\n",
@@ -553,6 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d2298303",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,6 +607,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1eb609e5",
    "metadata": {},
    "source": [
     "We define the values for the parameters as follows:"
@@ -569,6 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "662ae94c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,6 +625,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2fcbad50",
    "metadata": {},
    "source": [
     "Note that we added Kelvins as units to `s` and `o`.\n",
@@ -586,6 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "15e3a33d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,6 +647,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0a0b179c",
    "metadata": {},
    "source": [
     "The remaining problem here is that the `GenericSeries` doesn't know the units of our dimensions `x` and `t`.\n",
@@ -608,6 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c4400dba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,6 +669,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5d754ecf",
    "metadata": {},
    "source": [
     "> **Additional note:** Actually, the `GenericSeries` doesn't require a unit for a dimension, but a \"dimensionality\" like length, time, temperature etc. It has no real relevance if you would assign seconds, minutes or hours to a dimension since the unit will be scaled internally\n",
@@ -632,6 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "01688660",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,6 +699,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "454d9103",
    "metadata": {},
    "source": [
     "Adding the correct units fixes the problem:"
@@ -653,6 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ff9a4f65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,6 +720,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b0c32445",
    "metadata": {},
    "source": [
     "In case you wonder, why all the output values are identical, have a look at the input units we used.\n",
@@ -673,6 +730,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f0b60656",
    "metadata": {},
    "source": [
     "### Parameter dimensions\n",
@@ -685,6 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fe317b17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,6 +752,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0ab6f1a0",
    "metadata": {},
    "source": [
     "`t` is our only variable and represents time.\n",
@@ -703,6 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "78d06501",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,6 +776,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5d10940b",
    "metadata": {},
    "source": [
     "In the output above, we notice that we got an additional dimension we did not define: `dim_0`.\n",
@@ -731,6 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6d6f8410",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,6 +810,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "da238f48",
    "metadata": {},
    "source": [
     "As you can see, we now have three dimensions, while only one is an actual variable of our expression.\n",
@@ -757,6 +821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dd93cb6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,6 +830,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4a2dc936",
    "metadata": {},
    "source": [
     "Parameters can also have more than one dimension:"
@@ -773,6 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c89123e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,6 +855,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5006db5f",
    "metadata": {},
    "source": [
     "Note that if you do not provide custom names for the dimensions, the `GenericSeries` will just enumerate them as in the example above.\n",
@@ -800,6 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fde35b19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,6 +883,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3392d10d",
    "metadata": {},
    "source": [
     "### Partial evaluation\n",
@@ -825,6 +895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "60d221c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,6 +904,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4808257d",
    "metadata": {},
    "source": [
     "In this case, we get a new expression-based `GenericSeries`.\n",
@@ -845,6 +917,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "456fed6f",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tutorials/measurement_chain.ipynb
+++ b/tutorials/measurement_chain.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4570b64e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,6 +22,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "74400d05",
    "metadata": {},
    "source": [
     "# `MeasurementChain` Tutorial\n",
@@ -58,6 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "62813cdc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +75,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a173c471",
    "metadata": {},
    "source": [
     "As you can see, we have created a `MeasurementChain` with the name \"Temperature measurement chain 1\". It's source is named \"Thermocouple 1\" and it produces an analog output signal in Volts. The specified measurement error is a fixed value of 0.1%. \n",
@@ -86,6 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3c367844",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,6 +104,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0e1be579",
    "metadata": {},
    "source": [
     "All we needed to specify apart from the name and error was the output signal type as \"digital\". We also removed the unit by providing an empty string as output unit since the AD conversion just yields a digital number that doesn't necessarily represent a physical quantity. \n",
@@ -109,6 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "330e7bd2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,6 +130,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "047f2004",
    "metadata": {},
    "source": [
     "Here we specify a function that describes the transformation of our digital number into an actual temperature value:\n",
@@ -150,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "811c09fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,6 +167,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec7cbe7a",
    "metadata": {},
    "source": [
     "The plot shows us the initial signal produced by the source on the left. To the right of the source signal all transformations and their resulting output signals are shown.\n",
@@ -172,6 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b5c86b8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,6 +195,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0d50f15e",
    "metadata": {},
    "source": [
     "The information we provide is similar as before. The only noteworthy thing here is, that the signal type and unit are wrapped into a separate `Signal` class. Now we can use this class to create a measurement chain:    "
@@ -192,6 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b7215d09",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,6 +214,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0e73b528",
    "metadata": {},
    "source": [
     "Next we create a `SignalTransformation` "
@@ -209,6 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12129811",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,6 +239,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f28c034a",
    "metadata": {},
    "source": [
     "The first three arguments are equivalent as when using the `create_transformation` method. The `type_transformation` parameter expects a string consisting of two letters that can either be \"A\" for analog and \"D\" for digital. The first letter is the expected input signal type and the second letter the output signal type.\n",
@@ -233,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0f230ec5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,6 +259,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bda8553",
    "metadata": {},
    "source": [
     "## Construction from equipment classes\n",
@@ -257,6 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "67a69b59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +287,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "31b88ca4",
    "metadata": {},
    "source": [
     "Now we simply create a measurement chain from them:"
@@ -276,6 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9ed2869e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d0d54173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,6 +317,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "66e965d3",
    "metadata": {},
    "source": [
     "If we add an equipment to the `MeasurementChain`, it won't just only store the corresponding transformation but also remember the equipment that provides it.\n",
@@ -305,6 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8abebd82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,6 +337,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4b08b02",
    "metadata": {},
    "source": [
     "It might also be the case that an equipment provides multiple sources or transformations.\n",
@@ -328,6 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5190d951",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,6 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dd92ea1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,6 +372,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c248a29e",
    "metadata": {},
    "source": [
     "You can also get the the `SignalSource` and `SignalTransformation` objects using:"
@@ -353,6 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2b8d2bf8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,6 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8921c3f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,6 +400,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c4024b87",
    "metadata": {},
    "source": [
     "Because a measurement chain can contain multiple transformations, you have to specify the name of the desired transformation when using `get_transformation`.\n",
@@ -381,6 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "da4c41c4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,6 +421,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d6cbd1e2",
    "metadata": {},
    "source": [
     "One can also get a list of all signals and transformations with:"
@@ -397,6 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0c10f37b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,6 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7889c2e0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,6 +449,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fd4e7441",
    "metadata": {},
    "source": [
     "## Attaching data\n",
@@ -426,6 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "22d83e47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,6 +473,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b4af0edf",
    "metadata": {},
    "source": [
     "As you can see in the following plot, the data is associated with the output signal of the last transformation:    "
@@ -444,6 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6e0fc8b8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,6 +491,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "696b7187",
    "metadata": {},
    "source": [
     "But what if we want to attach the raw data of our source too? \n",
@@ -462,6 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dbdcfbae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,6 +516,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ad463827",
    "metadata": {},
    "source": [
     "As can be seen in the next plot, we successfully added the data to the source:"
@@ -483,6 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4baf5725",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,6 +534,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0b845b49",
    "metadata": {},
    "source": [
     "Also note, that all functions that let you create a measurement chain or add a transformation provide an extra parameter to add the corresponding data.\n",
@@ -502,6 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9aba8bac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,6 +555,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "21d82389",
    "metadata": {},
    "source": [
     "We access the sources' data by adding its name to the function call:"
@@ -518,6 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "05fe3c39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,6 +573,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "167b5b67",
    "metadata": {},
    "source": [
     "Remember, that the returned `TimeSeries` possesses a plot function that lets you create a plot of the time dependent data:"
@@ -534,6 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cbad01c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,6 +591,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ee90eac9",
    "metadata": {},
    "source": [
     "Note that the `Signal` class returned by the `get_signal` function offers a `plot` function too.\n",
@@ -551,6 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "92c1aa35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,6 +610,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "68f230f7",
    "metadata": {},
    "source": [
     "This concludes this tutorial about the `MeasurementChain` class.\n",

--- a/tutorials/weldxfile.ipynb
+++ b/tutorials/weldxfile.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "96caa2e2",
    "metadata": {},
    "source": [
     "# How to handle WelDX files\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "61c3a806",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,6 +28,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4608fefb",
    "metadata": {},
    "source": [
     "## Basic operations\n",
@@ -35,6 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c5df3d6c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,6 +48,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "25a3dd0c",
    "metadata": {},
    "source": [
     "Next we assign some dictionary like data to the file, by storing it some attribute name enclosed by square brackets.\n",
@@ -55,6 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "120d339b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,6 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "290a2547",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,6 +80,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5af720d1",
    "metadata": {},
    "source": [
     "Note, that here we are using some very common types, namely an NumPy array and a timestamp. For weldx specialized types like the coordinates system manager, (welding) measurements etc., the weldx package provides ASDF extensions to handle those types automatically during loading and saving ASDF data. You do not need to worry about them. If you try to save types, which cannot be handled by ASDF, you will trigger an error."
@@ -80,6 +88,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4ca8c5e",
    "metadata": {},
    "source": [
     "We could also have created the same structure in one step:"
@@ -88,6 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b5db6cb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +107,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f56f6283",
    "metadata": {},
    "source": [
     "You might have noticed, that we got a warning about the in-memory operation during showing the file in Jupyter.\n",
@@ -106,6 +117,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cd344fda",
    "metadata": {},
    "source": [
     "We can use all dictionary operations on the data we like, e.g. update, assign, and delete items."
@@ -114,6 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bcd58f9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,6 +139,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70ebacca",
    "metadata": {},
    "source": [
     "We can also iterate over all keys as usual. You can also have a look at the documentation of the builtin type `dict` for a complete overview of its features. "
@@ -134,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "89f9844f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ff08669",
    "metadata": {},
    "source": [
     "### Access to data by attributes\n",
@@ -152,6 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ed6164a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,6 +178,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9e8c2f4b",
    "metadata": {},
    "source": [
     "## Writing files to disk\n",
@@ -170,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "18d44c4d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,6 +197,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06ebb4c7",
    "metadata": {},
    "source": [
     "This newly created file can be opened up again, in read-write mode like by passing the appropriate arguments."
@@ -186,6 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6368ef1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,6 +217,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "946cb5be",
    "metadata": {},
    "source": [
     "Note, that we closed the file here explicitly. Before closing, we wanted to write a simple item to tree. But lets see what happens, if we open the file once again."
@@ -204,6 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7988fa48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,6 +237,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9318aea6",
    "metadata": {},
    "source": [
     "As you see the `updated` state has been written, because we closed the file properly. If we omit closing the file, \n",
@@ -222,6 +246,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8af250a2",
    "metadata": {},
    "source": [
     "## Handling updates within a context manager\n",
@@ -234,6 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9ed1032a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +274,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bc66f5d6",
    "metadata": {},
    "source": [
     "Let us inspect the file once again, to see whether our `updated` item has been correctly written. "
@@ -256,6 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "662d83bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,6 +292,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7c6b45e5",
    "metadata": {},
    "source": [
     "In case an error got triggered (e.g. an exception has been raised) inside the context, the underlying file is still updated. You could prevent this behavior, by passing `sync=False` during file construction.  "
@@ -272,6 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "768ee02a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e57b9a64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,6 +325,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1d260138",
    "metadata": {},
    "source": [
     "## Keeping a log of changes when manipulating a file\n",
@@ -303,6 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "37bc8da4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,6 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "809b06cf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,6 +357,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "265d11c1",
    "metadata": {},
    "source": [
     "When you want to describe a custom software,\n",
@@ -332,6 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5c5d7202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,6 +381,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4579876c",
    "metadata": {},
    "source": [
     "Let's now inspect how we wrote history."
@@ -353,6 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "65de7f43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,6 +399,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ae63fb1",
    "metadata": {},
    "source": [
     "The entries key is a list of all log entries, where new entries are appended to. We have proper time stamps indicating when the change happened, the actual log entry, and optionally a custom software used to make the change."
@@ -368,6 +407,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce4023bb",
    "metadata": {},
    "source": [
     "## Handling of custom schemas\n",
@@ -378,6 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "81c6ab8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,6 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "516a6279",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,6 +438,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e779898",
    "metadata": {},
    "source": [
     "This schema defines a complete experimental setup with measurement data, e.g requires the following attributes to be defined in our tree:\n",
@@ -414,6 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4b6dfba4",
    "metadata": {
     "tags": []
    },
@@ -427,6 +471,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f4421776",
    "metadata": {
     "tags": [
      "output_scroll"
@@ -440,6 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f1f60167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,6 +494,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "256dc52d",
    "metadata": {},
    "source": [
     "But what would happen, if we forget an import attribute? Lets have a closer look..."
@@ -456,6 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "75e782c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,6 +519,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7d8004a8",
    "metadata": {},
    "source": [
     "We receive a ValidationError from the ASDF library, which tells us exactly what the missing information is. The same will happen, if we accidentally pass the wrong type."
@@ -479,6 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f082e1e8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,6 +544,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1bd9b36f",
    "metadata": {},
    "source": [
     "Here we see, that a `signal` tag is expected, but a `asdf/core/ndarray-1.0.0` was received. \n",
@@ -505,6 +556,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bfdce65a",
    "metadata": {},
    "source": [
     "## Summary\n",


### PR DESCRIPTION
## Changes

Generated cell ids with nbformat.normalize

## Related Issues

A workaround PR #806 

## Checks
- [x] update example/tutorial notebooks


## Related tools
nbformat=5.7

script:
``` python
import json
from glob import glob

import nbformat
from nbformat.validator import normalize

nbs = glob("*.ipynb")
for n in nbs:
    with open(n) as fh:
        print(f"loading file {n}")
        nb_data = json.load(fh)
    n_changes, nb_norm = normalize(nb_data)
    if n_changes > 0:
        print(f"rewriting notebook {n}")
        NB = nbformat.from_dict(nb_norm)
        with open(n, 'w') as fh2:
            nbformat.write(NB, fh2, version=4)
```