### PR TITLE
Conda recipe fix deps

### DIFF
--- a/devtools/conda.recipe/meta.yaml
+++ b/devtools/conda.recipe/meta.yaml
@@ -46,8 +46,6 @@ test:
     {% for dep in proj.get('optional-dependencies')["test"] %}
     - {{ dep }}
     {% endfor %}
-    #- pytest
-    #- pytest-xdist
     - black
   files:
     - conftest.py

--- a/devtools/conda.recipe/meta.yaml
+++ b/devtools/conda.recipe/meta.yaml
@@ -32,14 +32,23 @@ requirements:
     - {{ dep.lower() }}
     {% endfor %}
 
+    # optional feature dependencies
+    {% for feature, dep_list in proj.get('optional-dependencies').items() %}
+    {% if feature != "test" %}
+    {% for dep in dep_list %}
+    - {{ dep }}
+    {% endfor %}
+    {% endif %}
+    {% endfor %}
+
 test:
   requires:
-    - pip
-    - pytest
-    - pytest-xdist
+    {% for dep in proj.get('optional-dependencies')["test"] %}
+    - {{ dep }}
+    {% endfor %}
+    #- pytest
+    #- pytest-xdist
     - black
-    # require wx-widgets here, so we can properly load the visualization sub-package.
-    - weldx_widgets
   files:
     - conftest.py
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
     "nbval",
   ]
 vis = [
-    "weldx_widgets >= 0.2",
+    "weldx_widgets >=0.2",
 ]
 
 # ASDF extension entry points.


### PR DESCRIPTION
## Changes
Since conda does not know the concept of optional dependencies, so we install
all optional features from pyproject.toml to ensure everything is
working.
The test dependencies are also obtained from pyproject.toml
