### PR TITLE
Fix pint-0.20 support and fix test warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ fixes
    advanced integration methods and fixes lengths computation of `DynamicShapeSegment` [:pull:`770`].
 -  Fix errors in tutorial about quality standards [:pull:`777`]
 -  Correct wrong handling of absolute times of the `TimeSeries` class [:pull:`791`]
+-  Added support for Pint 0.20 [:pull:`818`].
 
 ********************
  0.6.1 (19.05.2022)

--- a/weldx/tags/units/pint_quantity.py
+++ b/weldx/tags/units/pint_quantity.py
@@ -17,8 +17,9 @@ class PintQuantityConverter(WeldxConverter):
         "tag:stsci.edu:asdf/unit/quantity-1.*",
     ]
     types = [
-        "pint.quantity.build_quantity_class.<locals>.Quantity",
+        "pint.quantity.build_quantity_class.<locals>.Quantity",  # pint < 0.20
         "weldx.constants.Q_",
+        "pint.quantity.Quantity",  # pint >= 0.20
     ]
 
     def to_yaml_tree(self, obj: pint.Quantity, tag: str, ctx) -> dict:
@@ -54,8 +55,9 @@ class PintUnitConverter(WeldxConverter):
 
     tags = ["asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"]
     types = [
-        "pint.unit.build_unit_class.<locals>.Unit",
+        "pint.unit.build_unit_class.<locals>.Unit",  # pint < 0.20
         "weldx.constants.U_",
+        "pint.unit.Unit",  # pint >= 0.20
     ]
 
     def to_yaml_tree(self, obj: pint.Unit, tag: str, ctx) -> str:

--- a/weldx/tags/units/pint_quantity.py
+++ b/weldx/tags/units/pint_quantity.py
@@ -17,9 +17,9 @@ class PintQuantityConverter(WeldxConverter):
         "tag:stsci.edu:asdf/unit/quantity-1.*",
     ]
     types = [
+        "pint.quantity.Quantity",  # pint >= 0.20
         "pint.quantity.build_quantity_class.<locals>.Quantity",  # pint < 0.20
         "weldx.constants.Q_",
-        "pint.quantity.Quantity",  # pint >= 0.20
     ]
 
     def to_yaml_tree(self, obj: pint.Quantity, tag: str, ctx) -> dict:
@@ -55,9 +55,9 @@ class PintUnitConverter(WeldxConverter):
 
     tags = ["asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"]
     types = [
+        "pint.unit.Unit",  # pint >= 0.20
         "pint.unit.build_unit_class.<locals>.Unit",  # pint < 0.20
         "weldx.constants.U_",
-        "pint.unit.Unit",  # pint >= 0.20
     ]
 
     def to_yaml_tree(self, obj: pint.Unit, tag: str, ctx) -> str:

--- a/weldx/tests/asdf_tests/test_asdf_groove.py
+++ b/weldx/tests/asdf_tests/test_asdf_groove.py
@@ -1,7 +1,7 @@
 """Test all ASDF groove implementations."""
-
 import pytest
 from decorator import contextmanager
+from matplotlib import pylab
 
 from weldx.asdf.util import write_read_buffer
 from weldx.constants import Q_
@@ -50,7 +50,10 @@ def test_asdf_groove(groove: IsoBaseGroove, expected_dtype):
     ), f"Error calling plot function of {type(groove)} "
 
     # call plot function
-    groove.plot()
+    try:
+        groove.plot()
+    finally:
+        pylab.close()
 
 
 def test_asdf_groove_exceptions():

--- a/weldx/tests/asdf_tests/test_asdf_time.py
+++ b/weldx/tests/asdf_tests/test_asdf_time.py
@@ -27,7 +27,7 @@ def test_time_classes(inputs, time_ref):
     data = write_read_buffer({"root": inputs})
     assert np.all(data["root"] == inputs)
 
-    if isinstance(inputs, pd.Index) and not inputs.is_monotonic:
+    if isinstance(inputs, pd.Index) and not inputs.is_monotonic_increasing:
         # this is not valid for the time class, hence cancel here
         return
 

--- a/weldx/tests/asdf_tests/test_asdf_util.py
+++ b/weldx/tests/asdf_tests/test_asdf_util.py
@@ -197,19 +197,21 @@ class TestProtectedView(unittest.TestCase):
         self.view = _ProtectedViewDict(protected_keys=[self.protected_key], data=data)
 
     def test_protected_keys_hidden(self):
-        assert self.protected_key not in self.view.keys()
-        assert self.protected_key not in self.view
-        assert (self.protected_key, 42) not in self.view.items()
+        with pytest.warns(UserWarning, match="tried to manipulate"):
+            assert self.protected_key not in self.view.keys()
+            assert self.protected_key not in self.view
+            assert (self.protected_key, 42) not in self.view.items()
 
     def test_allowed_access(self):
         assert self.view["foo"] == "blub"
 
     def test_illegal_access(self):
-        with pytest.raises(KeyError):
-            _ = self.view["bar"]
+        with pytest.warns(UserWarning, match="tried to manipulate"):
+            with pytest.raises(KeyError):
+                _ = self.view["bar"]
 
-        with pytest.raises(KeyError):
-            del self.view["bar"]
+            with pytest.raises(KeyError):
+                del self.view["bar"]
 
     def test_access_non_existent(self):
         with pytest.raises(KeyError):

--- a/weldx/tests/test_core.py
+++ b/weldx/tests/test_core.py
@@ -1,5 +1,5 @@
 """Tests of the core package."""
-
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -503,9 +503,9 @@ class TestTimeSeries:
     def test_interp_time_warning():
         """Test if a warning is emitted when interpolating already interpolated data."""
         ts = TimeSeries(data=Q_([1, 2, 3], "m"), time=Q_([0, 1, 2], "s"))
-        with pytest.warns(None) as recorded_warnings:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=UserWarning)
             ts_interp = ts.interp_time(Q_([0.25, 0.5, 0.75, 1], "s"))
-        assert not any(w.category == UserWarning for w in recorded_warnings)
 
         with pytest.warns(UserWarning):
             ts_interp.interp_time(Q_([0.4, 0.6], "s"))

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -129,8 +129,15 @@ def test_time_warning(coordinates, orientation, time, warning):
         Expected warning
 
     """
-    with pytest.warns(warning):
+
+    def _call():
         LCS(coordinates=coordinates, orientation=orientation, time=time)
+
+    if warning is not None:  # pytest.warns does not allow passing None
+        with pytest.warns(warning):
+            _call()
+    else:
+        _call()
 
 
 # test_init_time_dsx -------------------------------------------------------------------

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -1,6 +1,7 @@
 """Test the `LocalCoordinateSystem` class."""
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -137,7 +138,9 @@ def test_time_warning(coordinates, orientation, time, warning):
         with pytest.warns(warning):
             _call()
     else:
-        _call()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=UserWarning)
+            _call()
 
 
 # test_init_time_dsx -------------------------------------------------------------------


### PR DESCRIPTION
## Changes
- Urgent fix for pint-0.20, which renamed the classes Unit and Quantity. 
- Fixed several warnings during testing

## Related Issues

Closes #819 

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests


## TODO
Sphinx errors/warnings
- [ ] Cannot resolve forward reference in type annotations of "weldx.U_": name 'Unit' is not defined
- [ ] docstring of weldx.ArcSegment.arc_angle:1: WARNING: py:class reference target not found: pint.Quantity