### PR TITLE
Fix wxextension matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,16 @@ readme = {file = "README.rst", content-type="text/x-rst"}
 license = {file = "LICENSE", name="BSD License"}
 keywords = [
     "welding",
-    "weldx",
-    "bam", # TODO: add more keywords here! think of them as in a journal article.
+    "measurement",
+    "experiment",
+    "coordinate transformations",
+    "time dependent coordinates",
+    "BAM",
+    "Bundesanstalt für Materialforschung- und Prüfung",
+    "scientific data format",
+    "asdf",
+    "advanced-scientific-data-format",
+    "iso-9692-1",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -455,8 +455,12 @@ def get_weldx_extension(ctx: Union[SerializationContext, AsdfConfig]) -> Extensi
     extensions = [
         ext for ext in extensions if str(ext.extension_uri) == WELDX_EXTENSION_URI
     ]
-    if not len(extensions) == 1:
-        raise ValueError("Could not determine correct weldx extension.")
+    # Note: as of asdf-2.14.0 two extensions match the above expression. Prior to this
+    # version we just received one match. So we will just check for at least one.
+    if not extensions:
+        raise RuntimeError(
+            "could not find Weldx asdf extension. " "Check your installation."
+        )
     return extensions[0]
 
 

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -466,7 +466,7 @@ def get_weldx_extension(ctx: Union[SerializationContext, AsdfConfig]) -> Extensi
     from weldx import __version__ as imported_version
 
     if not all(e.package_version == imported_version for e in extensions):
-        mismatch = [e.package_version != imported_version for e in extensions]
+        mismatch = [e for e in extensions if e.package_version != imported_version]
         raise EnvironmentError(
             "Weldx extension version mismatch. Wanted extension "
             f"for version {imported_version}, but got: "

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -1,6 +1,7 @@
 """Utilities for asdf files."""
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable, Mapping, Set
 from io import BytesIO, TextIOBase
 from pathlib import Path
@@ -444,6 +445,7 @@ def dataclass_serialization_class(
     return _SerializationClass
 
 
+@functools.cache
 def get_weldx_extension(ctx: Union[SerializationContext, AsdfConfig]) -> Extension:
     """Grab the weldx extension from list of current active extensions."""
     if isinstance(ctx, asdf.asdf.SerializationContext):
@@ -461,6 +463,16 @@ def get_weldx_extension(ctx: Union[SerializationContext, AsdfConfig]) -> Extensi
         raise RuntimeError(
             "could not find Weldx asdf extension. " "Check your installation."
         )
+    from weldx import __version__ as imported_version
+
+    if not all(e.package_version == imported_version for e in extensions):
+        mismatch = [e.package_version != imported_version for e in extensions]
+        raise EnvironmentError(
+            "Weldx extension version mismatch. Wanted extension "
+            f"for version {imported_version}, but got: "
+            f"{[e.package_version for e in mismatch]}"
+        )
+
     return extensions[0]
 
 


### PR DESCRIPTION
## Changes

asdf-2.14.0+ returns two `Extension` instances matching the pattern in `get_weldx_extension()`. So we allow this now and add a version mismatch check.
Another minor change is to add caching to the function, as it is being called for some types, each time one of these types is being serialized. The cache hits, if the extension tuple matches (based on id(), I'd guess).

## Related Issues

Closes #825

## Checks

- [ ] updated CHANGELOG.rst
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
