### PR TITLE
remove get_highest_tag_version from converters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ dependencies
 
 -  pin ``asdf<2.14`` due to changes in the extension mechanism [:pull:`828`].
 
+changes
+=======
+
+- remove outdated calls to ``weldx.asdf.util.get_highest_tag_version`` in ``TimeSeries`` and ``SpatialData`` converters [:pull:`831`]
+
 ********************
  0.6.2 (07.11.2022)
 ********************

--- a/weldx/tags/core/geometry/spatial_data.py
+++ b/weldx/tags/core/geometry/spatial_data.py
@@ -1,7 +1,6 @@
 from copy import copy
 
 from weldx.asdf.types import WeldxConverter
-from weldx.asdf.util import get_highest_tag_version
 from weldx.geometry import SpatialData
 
 __all__ = ["SpatialDataConverter"]
@@ -27,7 +26,3 @@ class SpatialDataConverter(WeldxConverter):
         if tag == "asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.0":
             node["coordinates"] = Q_(node["coordinates"], "mm")  # legacy
         return SpatialData(**node)
-
-    def select_tag(self, obj, tags, ctx) -> str:
-        """Determine the output tag for serialization."""
-        return get_highest_tag_version(self.tags)

--- a/weldx/tags/core/time_series.py
+++ b/weldx/tags/core/time_series.py
@@ -5,7 +5,6 @@ import pint
 from asdf.tagged import TaggedDict
 
 from weldx.asdf.types import WeldxConverter
-from weldx.asdf.util import get_highest_tag_version
 from weldx.constants import Q_
 from weldx.core import TimeSeries
 
@@ -45,10 +44,6 @@ class TimeSeriesConverter(WeldxConverter):
             return TimeSeries(values, time, interpolation)
 
         return TimeSeries(node["expression"])  # mathexpression
-
-    def select_tag(self, obj, tags, ctx) -> str:
-        """Determine the output tag for serialization."""
-        return get_highest_tag_version(self.tags)
 
     @staticmethod
     def shape_from_tagged(node: TaggedDict) -> list[int]:


### PR DESCRIPTION
## Changes

- remove `get_highest_tag_version` and use default tag selection in `TimeSeries` and `SpatialData` converters 

## Checks

- [x] updated CHANGELOG.rst