### PR TITLE
Unpin ASDF

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ dependencies
 ============
 
 -  pin ``asdf<2.14`` due to changes in the extension mechanism [:pull:`828`].
+-  Unpin ``asdf`` due to fix in ``asdf 2.14.3`` release [:pull:`834`].
 
 changes
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.8,<3.11"
 dependencies = [
     "numpy >=1.20",
-    "asdf >=2.8.2,<2.14",
+    "asdf >=2.8.2,!=2.14.0,!=2.14.1,!=2.14.2",
     "pandas >=1.0",
     "xarray >=0.19,<2022.09.0",
     "scipy >=1.4,!=1.6.0,!=1.6.1",


### PR DESCRIPTION
## Changes

This PR unpins asdf. In asdf version 2.14.3 we specifically fixed the bug introduced in asdf 2.14.0 which lead to #825. This means weldx should be able to unpin asdf now.

Note that I specifically excluded the asdf versions: 2.14.0, 2.14.1, and 2.14.2 as they all experience the bug reported in #825.

## Related Issues

Closes #825

## Checks

- [x] updated CHANGELOG.rst
