### PR TITLE
Unpin maximum Python version

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -81,7 +81,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: ~/.cache/pip
-          key: ubuntu-latest-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.cfg') }}
+          key: ubuntu-latest-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}
 
       - name: pip installs
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,10 +32,33 @@ jobs:
         os: [ubuntu-latest]
         py: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: ./github/actions/checkout_create_env
+      - uses: actions/checkout@v3
         with:
-          python_version: ${{ matrix.py }}
+          fetch-depth: '0' # Fetch all history for all tags and branches
+
+      - uses: CagtayFabry/pydeps2env@main
+        with:
+          file: 'pyproject.toml'
+          channels: 'conda-forge defaults'
           extras: 'test vis'
+          setup_requires: 'include'
+
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ./environment.yml
+          environment-name: weldx
+          cache-env: true
+          extra-specs: |
+            python=${{ matrix.py }}
+            wheel
+            pip
+
+      - name: activate env
+        run: micromamba activate weldx
+
+      - name: pip installs
+        run: |
+          python -m pip install -e .
 
       - name: install cookiecutter
         if: matrix.py == '3.8'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,35 +30,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: ['3.8', '3.9', '3.10']
+        py: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v3
+      - uses: ./github/actions/checkout_create_env
         with:
-          fetch-depth: '0' # Fetch all history for all tags and branches
-
-      - uses: CagtayFabry/pydeps2env@main
-        with:
-          file: 'pyproject.toml'
-          channels: 'conda-forge defaults'
+          python_version: ${{ matrix.py }}
           extras: 'test vis'
-          setup_requires: 'include'
-
-      - uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: ./environment.yml
-          environment-name: weldx
-          cache-env: true
-          extra-specs: |
-            python=${{ matrix.py }}
-            wheel
-            pip
-
-      - name: activate env
-        run: micromamba activate weldx
-
-      - name: pip installs
-        run: |
-          python -m pip install -e .
 
       - name: install cookiecutter
         if: matrix.py == '3.8'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,12 +11,13 @@ dependencies
 
 -  pin ``asdf<2.14`` due to changes in the extension mechanism [:pull:`828`].
 -  Unpin ``asdf`` due to fix in ``asdf 2.14.3`` release [:pull:`834`].
+-  Unpin maximum Python version (again). [:pull:`837`].
 
 changes
 =======
 
-- remove outdated calls to ``weldx.asdf.util.get_highest_tag_version`` in ``TimeSeries`` and ``SpatialData`` converters [:pull:`831`]
--  use Ruff in pre-commit-action [:pull:`824`].
+- Remove outdated calls to ``weldx.asdf.util.get_highest_tag_version`` in ``TimeSeries`` and ``SpatialData`` converters [:pull:`831`]
+- Use Ruff in pre-commit-action [:pull:`824`].
 
 ********************
  0.6.2 (07.11.2022)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,8 @@ dependencies
 changes
 =======
 
-- Remove outdated calls to ``weldx.asdf.util.get_highest_tag_version`` in ``TimeSeries`` and ``SpatialData`` converters [:pull:`831`]
-- Use Ruff in pre-commit-action [:pull:`824`].
+- remove outdated calls to ``weldx.asdf.util.get_highest_tag_version`` in ``TimeSeries`` and ``SpatialData`` converters [:pull:`831`]
+-  use Ruff in pre-commit-action [:pull:`824`].
 
 ********************
  0.6.2 (07.11.2022)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 # Dependencies
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.8"
 dependencies = [
     "numpy >=1.20",
     "asdf >=2.8.2,!=2.14.0,!=2.14.1,!=2.14.2",

--- a/weldx/tags/debug/test_shape_validator.py
+++ b/weldx/tags/debug/test_shape_validator.py
@@ -15,20 +15,22 @@ __all__ = ["ShapeValidatorTestClass", "ShapeValidatorTestClassConverter"]
 class ShapeValidatorTestClass:
     """Helper class to test the shape validator"""
 
-    prop1: np.ndarray = np.ones((1, 2, 3))
-    prop2: np.ndarray = np.ones((3, 2, 1))
-    prop3: np.ndarray = np.ones((2, 4, 6, 8, 10))
-    prop4: np.ndarray = np.ones((1, 3, 5, 7, 9))
+    prop1: np.ndarray = field(default_factory=lambda: np.ones((1, 2, 3)))
+    prop2: np.ndarray = field(default_factory=lambda: np.ones((3, 2, 1)))
+    prop3: np.ndarray = field(default_factory=lambda: np.ones((2, 4, 6, 8, 10)))
+    prop4: np.ndarray = field(default_factory=lambda: np.ones((1, 3, 5, 7, 9)))
     prop5: float = 3.141
     quantity: pint.Quantity = Q_(10, "m")
-    timeseries: TimeSeries = TimeSeries(Q_(10, "m"))
+    timeseries: TimeSeries = field(default_factory=lambda: TimeSeries(Q_(10, "m")))
     nested_prop: dict = field(
         default_factory=lambda: {
             "p1": np.ones((10, 8, 6, 4, 2)),
             "p2": np.ones((9, 7, 5, 3, 1)),
         }
     )
-    time_prop: pd.DatetimeIndex = pd.timedelta_range("0s", freq="s", periods=9)
+    time_prop: pd.DatetimeIndex = field(
+        default_factory=lambda: pd.timedelta_range("0s", freq="s", periods=9)
+    )
     optional_prop: np.ndarray = None
 
 

--- a/weldx/tags/debug/test_unit_validator.py
+++ b/weldx/tags/debug/test_unit_validator.py
@@ -25,7 +25,9 @@ class UnitValidatorTestClass:
     simple_prop: dict = field(default_factory=lambda: dict(value=float(3), units="m"))
     delta_prop: dict = Q_(100, "Δ°C")
     dimensionless: Union[float, int, np.ndarray, pint.Quantity, xr.DataArray] = 3.14
-    custom_object: Any = TimeSeries(Q_([0, 5], "A"), Q_([0, 1], "s"))
+    custom_object: Any = field(
+        default_factory=lambda: TimeSeries(Q_([0, 5], "A"), Q_([0, 1], "s"))
+    )
 
 
 UnitValidatorTestClassConverter = dataclass_serialization_class(


### PR DESCRIPTION
## Changes

We allow future versions again. A very detailed discussion why pinning maximum versions can be found here: https://iscinumpy.dev/post/bound-version-constraints/

Also fixed some dataclasses in asdf.tags.debug 

TLDR:
Never cap Python, it is fundamentally broken at the moment. Also, even packing capping has negative consequences that can produce unexpected solves.

## Related Issues

Closes #836 

## Checks

- [x] updated CHANGELOG.rst
