### PR TITLE
update ruff 233, nbqa 1.6.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.230
+    rev: v0.0.233
     hooks:
       - id: ruff
         args:
@@ -41,7 +41,7 @@ repos:
           - --fix
   # ----- Jupyter Notebooks -----
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.0
+    rev: 1.6.1
     hooks:
       - id: nbqa-black
       - id: nbqa-ruff  # ruff handles isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,12 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.213
+    rev: v0.0.230
     hooks:
       - id: ruff
         args:
           - --quiet
           - --fix
-          - --force-exclude
   # ----- Jupyter Notebooks -----
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.0


### PR DESCRIPTION
## Changes

update ruff to 230 which has `--force-exclude` set by default

Not sure if this propagates to NBQA
