### PR TITLE
[WXFile] determine widget usage by runtime env in _ipython_display_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   `TimeSeries` and `SpatialData` converters \[{pull}`831`\].
 - Use Ruff in pre-commit-action \[{pull}`824`\].
 - Use MyST-NB for documentation building \[{pull}`830`\].
+- `WeldxFile` correctly determines whether to display the header via widgets or text \[{pull}`848`\].
 
 ## 0.6.2 (07.11.2022)
 

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -916,10 +916,12 @@ class WeldxFile(_ProtectedViewDict):
         return self.header(*args, **kwargs)
 
     def _ipython_display_(self):
-        # this will be called in Jupyter Lab, but not in a plain notebook.
+        # This will be called in Jupyter Lab, and myst-nb execution,
+        # but not in a plain notebook.
         from IPython.core.display import display
 
-        display(self.header(use_widgets=True, _interactive=True))
+        # Determine widget usage by runtime environment, by passing None.
+        display(self.header(use_widgets=None, _interactive=True))
 
     def info(
         self,


### PR DESCRIPTION
Fixes #846

## Changes

In `_ipython_display_` we assumed, that it will only be called in a Jupyter lab environment. This ain't true - within a Sphinx environment it's also called. So we just let this state be determined automatically.

## Related Issues

Closes #846

## Checks

- [x] updated CHANGELOG.rst
- [ ] updated tests
- [ ] updated doc/
- [ ] update example/tutorial notebooks
- [ ] update manifest file
