### PR TITLE
update pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ published under an appropriate open source license. By using the file
 format objectivity, comparability and reproducibility across different
 experimental setups can be improved.
 
-The project is under active development by the \[Welding Technology\]
-(https://www.bam.de/Navigation/EN/About-us/Organisation/Organisation-Chart/President/Department-9/Division-93/division93.html)
+The project is under active development by the [Welding Technology](https://www.bam.de/Navigation/EN/About-us/Organisation/Organisation-Chart/President/Department-9/Division-93/division93.html)
 division at Bundesanstalt für Materialforschung und -prüfung (BAM).
 
 ## Features

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,8 +24,7 @@ A short primer in the steps needed to release a new version of the `weldx` packa
   - [ ] name the release **git tag** according to the version released (e.g. **v0.3.3**)
   - [ ] name the GitHub release accordingly, omitting the **v** prefix (this can be change later so don't worry, in
     doubt use **vX.Y.Z** everywhere)
-  - [ ] copy the changes/release notes of the current version into the description
-    ([this website](https://mystyc.herokuapp.com/) can be used to convert rST -> MD)
+  - [ ] copy the changes/release notes of the current version into the description and change the GitHub PR links to GitHub markdown
 - [ ] wait for all Github Actions to finish
 
 ## ReadTheDocs updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
 documentation = "https://weldx.readthedocs.io"
 repository = "https://github.com/BAMweldx/weldx"
 bug_tracker = "https://github.com/BAMweldx/weldx/issues"
-changelog = "https://github.com/BAMweldx/weldx/blob/master/CHANGELOG.rst"
+changelog = "https://github.com/BAMweldx/weldx/blob/master/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name="Martin K. Scherer", email="martin.scherer@bam.de"},
 ]
 description = "Python API for the WelDX file format and standard"
-readme = {file = "README.rst", content-type="text/x-rst"}
+readme = "README.md"
 license = {file = "LICENSE", name="BSD License"}
 keywords = [
     "welding",


### PR DESCRIPTION
## Changes

link to markdown README and CHANGELOG files in pyproject.toml

fixes #852 