### PR TITLE
quantify xarray parameters in MathematicalExpression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- fix non quantified xarray parameter inputs to `MathematicalExpression` \[{pull}`863`\].
+- fix non quantified xarray parameter inputs to `MathematicalExpression` \[{pull}`864`\].
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 0.6.5 (unreleased)
 
+### Fixes
+
+- fix non quantified xarray parameter inputs to `MathematicalExpression` \[{pull}`863`\].
+
 ### Dependencies
 
-- require XArray >= 2022.9.0, as `LocalCoordinateSystem` now handles merges correctly \[{pull}`861`\].
+- require `xarray >= 2022.9.0`, as `LocalCoordinateSystem` now handles merges correctly \[{pull}`861`\].
 
 ## 0.6.4 (09.02.2023)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "scipy >=1.4,!=1.6.0,!=1.6.1",
     "sympy >=1.6",
     "pint >=0.18",
-    "pint-xarray >=0.2.1",
+    "pint-xarray >=0.3",
     "bottleneck >=1.3.3",
     "boltons",
     "bidict",

--- a/weldx/core/math_expression.py
+++ b/weldx/core/math_expression.py
@@ -86,6 +86,8 @@ class MathematicalExpression:
         """
         return self.equals(other, check_parameters=True, check_structural_equality=True)
 
+    __hash__ = None
+
     def equals(
         self,
         other: Any,

--- a/weldx/core/math_expression.py
+++ b/weldx/core/math_expression.py
@@ -169,6 +169,9 @@ class MathematicalExpression:
                 v = xr.DataArray(v[0], dims=v[1])
             if not isinstance(v, xr.DataArray):
                 v = Q_(v)
+            else:  # quantify as dimensionless if no unit provided
+                if v.weldx.units is None:
+                    v = v.pint.quantify("")
             self._parameters[k] = v
 
     @property

--- a/weldx/core/math_expression.py
+++ b/weldx/core/math_expression.py
@@ -172,6 +172,7 @@ class MathematicalExpression:
             else:  # quantify as dimensionless if no unit provided
                 if v.weldx.units is None:
                     v = v.pint.quantify("")
+                v = v.pint.quantify()
             self._parameters[k] = v
 
     @property

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -851,7 +851,7 @@ class TestMathematicalExpression:
             (Q_([1, 2, 3], "m"), Q_([4, 5, 6], "m")),
             (
                 xr.DataArray(Q_([1, 2], "m"), dims=["a"]),
-                xr.DataArray(Q_([3, 4], "m"), dims=["b"]),
+                xr.DataArray(Q_([3, 4], "m"), dims=["b"]).pint.dequantify(),
             ),
             (
                 xr.DataArray([1, 2], dims=["a"]),

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -847,10 +847,15 @@ class TestMathematicalExpression:
     @pytest.mark.parametrize(
         "a, b",
         [
+            ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
             (Q_([1, 2, 3], "m"), Q_([4, 5, 6], "m")),
             (
                 xr.DataArray(Q_([1, 2], "m"), dims=["a"]),
                 xr.DataArray(Q_([3, 4], "m"), dims=["b"]),
+            ),
+            (
+                xr.DataArray([1, 2], dims=["a"]),
+                xr.DataArray([3, 4], dims=["b"]),
             ),
             (
                 Q_([1, 2], "m"),

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -141,7 +141,6 @@ def get_xarray_example_dataset():
     -------
         Dataset for test purposes
     """
-
     temp_data = [
         [[15.0, 16.0, 17.0], [18.0, 19.0, 20.0]],
         [[21.0, 22.0, 23.0], [24.0, 25.0, 26.0]],


### PR DESCRIPTION
## Changes

- quantify unitless xarray input parameters as `dimensionless` in `MathematicalExpression` (same as non quantity numeric inputs)
- update `pint-xarray` dependency to  `0.3` for updated `pint.quantify()` behavior

## Related Issues

Closes #860

## Checks

- [x] updated CHANGELOG.rst
- [x] updated tests

