### PR TITLE
add read_buffer_context and write_read_buffer_context

### DIFF
--- a/weldx/tests/asdf_tests/test_asdf_aws_schema.py
+++ b/weldx/tests/asdf_tests/test_asdf_aws_schema.py
@@ -1,7 +1,7 @@
 """Test ASDF serialization of AWS schema definitions."""
 import pytest
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer_context
 from weldx.constants import Q_
 
 # weld design -----------------------------------------------------------------
@@ -100,7 +100,7 @@ def test_aws_example():
 
     tree = dict(process=process, weldment=weldment, base_metal=base_metal)
 
-    data = write_read_buffer(tree)
-    data.pop("asdf_library", None)
-    data.pop("history", None)
-    assert compare_nested(data, tree)
+    with write_read_buffer_context(tree) as data:
+        data.pop("asdf_library", None)
+        data.pop("history", None)
+        assert compare_nested(data, tree)

--- a/weldx/tests/asdf_tests/test_asdf_base_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_base_types.py
@@ -6,7 +6,7 @@ import pytest
 import xarray as xr
 from asdf import ValidationError
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer, write_read_buffer_context
 
 
 # --------------------------------------------------------------------------------------
@@ -28,12 +28,14 @@ def test_dataarray():
     da.attrs["long_name"] = "random velocity"
     # add metadata to coordinate
     da.x.attrs["units"] = "x units"
-    da2 = write_read_buffer({"da": da})["da"]
-    assert da2.identical(da)
+    with write_read_buffer_context({"da": da}) as data:
+        da2 = data["da"]
+        assert da2.identical(da)
 
 
 def test_dataset_children():
     da = xr.DataArray(np.arange(10), name="arr1", attrs={"name": "sample data"})
     ds = da.to_dataset()
-    ds2 = write_read_buffer({"ds": ds})["ds"]
-    assert ds2.identical(ds)
+    with write_read_buffer_context({"ds": ds}) as data:
+        ds2 = data["ds"]
+        assert ds2.identical(ds)

--- a/weldx/tests/asdf_tests/test_asdf_gmaw_process.py
+++ b/weldx/tests/asdf_tests/test_asdf_gmaw_process.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer_context
 from weldx.constants import Q_
 from weldx.core import TimeSeries
 from weldx.welding.processes import GmawProcess
@@ -65,5 +65,5 @@ from weldx.welding.processes import GmawProcess
     ],
 )
 def test_gmaw_process(inputs):
-    data = write_read_buffer({"root": inputs})
-    assert data["root"] == inputs
+    with write_read_buffer_context({"root": inputs}) as data:
+        assert data["root"] == inputs

--- a/weldx/tests/asdf_tests/test_asdf_graph.py
+++ b/weldx/tests/asdf_tests/test_asdf_graph.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import networkx as nx
 import pytest
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer, write_read_buffer_context
 
 # --------------------------------------------------------------------------------------
 # DiGraph
@@ -29,17 +29,17 @@ class TestDiGraph(unittest.TestCase):
 
     @staticmethod
     def _assert_roundtrip(g):
-        data = write_read_buffer(dict(graph=g))
-        g2 = data["graph"]
+        with write_read_buffer_context(dict(graph=g)) as data:
+            g2 = data["graph"]
 
-        for node in g:
-            assert g.nodes[node] == g2.nodes[node]
+            for node in g:
+                assert g.nodes[node] == g2.nodes[node]
 
-        for edge in g.edges:
-            assert g.edges[edge] == g2.edges[edge]
+            for edge in g.edges:
+                assert g.edges[edge] == g2.edges[edge]
 
-        assert set(g.nodes) == set(g2.nodes)
-        assert set(g.edges) == set(g2.edges)
+            assert set(g.nodes) == set(g2.nodes)
+            assert set(g.edges) == set(g2.edges)
 
     def test_graph_roundtrip(self):
         for g in [self.graph, self.graph_uuid]:

--- a/weldx/tests/asdf_tests/test_asdf_groove.py
+++ b/weldx/tests/asdf_tests/test_asdf_groove.py
@@ -2,7 +2,7 @@
 import pytest
 from decorator import contextmanager
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer_context
 from weldx.constants import _DEFAULT_LEN_UNIT, Q_
 from weldx.geometry import Profile
 from weldx.welding.groove.iso_9692_1 import (
@@ -46,22 +46,22 @@ def test_asdf_groove(groove: IsoBaseGroove, expected_dtype):
     k = "groove"
     tree = {k: groove}
 
-    data = write_read_buffer(tree)
-    assert isinstance(
-        data[k], expected_dtype
-    ), f"Did not match expected type {expected_dtype} on item {data[k]}"
-    # test content equality using dataclass built-in functions
-    assert (
-        groove == data[k]
-    ), f"Could not correctly reconstruct groove of type {type(groove)}"
-    # test to_profile
-    assert isinstance(
-        groove.to_profile(), Profile
-    ), f"Error calling plot function of {type(groove)} "
+    with write_read_buffer_context(tree) as data:
+        assert isinstance(
+            data[k], expected_dtype
+        ), f"Did not match expected type {expected_dtype} on item {data[k]}"
+        # test content equality using dataclass built-in functions
+        assert (
+            groove == data[k]
+        ), f"Could not correctly reconstruct groove of type {type(groove)}"
+        # test to_profile
+        assert isinstance(
+            groove.to_profile(), Profile
+        ), f"Error calling plot function of {type(groove)} "
 
-    # call plot function
-    with _close_plot():
-        groove.plot()
+        # call plot function
+        with _close_plot():
+            groove.plot()
 
 
 def test_asdf_groove_exceptions():

--- a/weldx/tests/asdf_tests/test_asdf_measurement.py
+++ b/weldx/tests/asdf_tests/test_asdf_measurement.py
@@ -1,6 +1,6 @@
 import pytest
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer_context
 from weldx.constants import Q_
 from weldx.core import MathematicalExpression
 from weldx.measurement import (
@@ -89,8 +89,8 @@ def measurement_chain_with_equipment() -> MeasurementChain:
 def test_measurement_chain(copy_arrays, lazy_load, measurement_chain):
     """Test the asdf serialization of the measurement chain."""
     tree = {"m_chain": measurement_chain}
-    data = write_read_buffer(
+    with write_read_buffer_context(
         tree, open_kwargs={"copy_arrays": copy_arrays, "lazy_load": lazy_load}
-    )
-    mc_file = data["m_chain"]
-    assert measurement_chain == mc_file
+    ) as data:
+        mc_file = data["m_chain"]
+        assert measurement_chain == mc_file

--- a/weldx/tests/asdf_tests/test_asdf_time.py
+++ b/weldx/tests/asdf_tests/test_asdf_time.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from weldx.asdf.util import write_buffer, write_read_buffer
+from weldx.asdf.util import write_buffer, write_read_buffer_context
 from weldx.time import Time
 
 
@@ -24,16 +24,17 @@ from weldx.time import Time
 )
 @pytest.mark.parametrize("time_ref", [None, pd.Timestamp.min + pd.Timedelta("10s")])
 def test_time_classes(inputs, time_ref):
-    data = write_read_buffer({"root": inputs})
-    assert np.all(data["root"] == inputs)
+    with write_read_buffer_context({"root": inputs}) as data:
+        assert np.all(data["root"] == inputs)
 
     if isinstance(inputs, pd.Index) and not inputs.is_monotonic_increasing:
         # this is not valid for the time class, hence cancel here
         return
 
     t1 = Time(inputs, time_ref)
-    t2 = write_read_buffer({"root": t1})["root"]
-    assert t1.equals(t2)
+    with write_read_buffer_context({"root": t1}) as data:
+        t2 = data["root"]
+        assert t1.equals(t2)
 
 
 def test_time_classes_max_inline():

--- a/weldx/tests/asdf_tests/test_asdf_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_types.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from weldx.asdf.util import write_read_buffer
+from weldx.asdf.util import write_read_buffer_context
 from weldx.constants import META_ATTR, USER_ATTR
 from weldx.measurement import Error
 from weldx.util import compare_nested
@@ -17,13 +17,12 @@ def test_meta_attr():
 
     tree = {"Error": e}
 
-    data = write_read_buffer(tree)
+    with write_read_buffer_context(tree) as data:
+        e2 = data["Error"]
 
-    e2 = data["Error"]
-
-    assert e2 == e
-    assert compare_nested(getattr(e2, META_ATTR), getattr(e, META_ATTR))
-    assert compare_nested(getattr(e2, USER_ATTR), getattr(e, USER_ATTR))
-    assert compare_nested(
-        getattr(getattr(e2, META_ATTR)["ts"], META_ATTR), getattr(ts, META_ATTR)
-    )
+        assert e2 == e
+        assert compare_nested(getattr(e2, META_ATTR), getattr(e, META_ATTR))
+        assert compare_nested(getattr(e2, USER_ATTR), getattr(e, USER_ATTR))
+        assert compare_nested(
+            getattr(getattr(e2, META_ATTR)["ts"], META_ATTR), getattr(ts, META_ATTR)
+        )

--- a/weldx/tests/asdf_tests/test_asdf_util.py
+++ b/weldx/tests/asdf_tests/test_asdf_util.py
@@ -15,7 +15,7 @@ from weldx.asdf.util import (
     get_highest_tag_version,
     get_schema_tree,
     get_yaml_header,
-    read_buffer,
+    read_buffer_context,
     write_buffer,
 )
 
@@ -168,9 +168,10 @@ def test_write_buffer_dummy_inline_arrays():
     buff = write_buffer(tree={name: array}, write_kwargs=dict(dummy_arrays=True))
 
     buff.seek(0)
-    restored = read_buffer(buff)[name]
-    assert restored.dtype == array.dtype
-    assert restored.shape == array.shape
+    with read_buffer_context(buff) as data:
+        restored = data[name]
+        assert restored.dtype == array.dtype
+        assert restored.shape == array.shape
 
 
 def test_get_highest_tag_version():

--- a/weldx/tests/asdf_tests/test_asdf_validators.py
+++ b/weldx/tests/asdf_tests/test_asdf_validators.py
@@ -6,7 +6,7 @@ import xarray as xr
 from asdf.exceptions import ValidationError
 
 from weldx.asdf.types import WxSyntaxError
-from weldx.asdf.util import write_buffer, write_read_buffer
+from weldx.asdf.util import write_buffer, write_read_buffer, write_read_buffer_context
 from weldx.asdf.validators import _custom_shape_validator
 from weldx.constants import Q_
 from weldx.core import TimeSeries
@@ -148,11 +148,10 @@ def test_shape_validation_error_exception(shape, exp, err):
     ],
 )
 def test_shape_validator(test_input):
-    result = write_read_buffer(
-        {"root": test_input},
-    )["root"]
-    assert compare_nested(test_input.__dict__, result.__dict__)
-    assert compare_nested(result.__dict__, test_input.__dict__)
+    with write_read_buffer_context({"root": test_input}) as data:
+        result = data["root"]
+        assert compare_nested(test_input.__dict__, result.__dict__)
+        assert compare_nested(result.__dict__, test_input.__dict__)
 
 
 @pytest.mark.parametrize(
@@ -186,16 +185,16 @@ def test_shape_validator_exceptions(test_input):
     ],
 )
 def test_unit_validator(test):
-    data = write_read_buffer({"root_node": test})
-    test_read = data["root_node"]
-    assert isinstance(data, dict)
-    assert test_read.length_prop == test.length_prop
-    assert test_read.velocity_prop == test.velocity_prop
-    assert np.all(test_read.current_prop == test.current_prop)
-    assert np.all(test_read.nested_prop["q1"] == test.nested_prop["q1"])
-    assert test_read.nested_prop["q2"] == test.nested_prop["q2"]
-    assert test_read.simple_prop == test.simple_prop
-    assert np.all(test_read.current_prop == test.current_prop)
+    with write_read_buffer_context({"root_node": test}) as data:
+        test_read = data["root_node"]
+        assert isinstance(data, dict)
+        assert test_read.length_prop == test.length_prop
+        assert test_read.velocity_prop == test.velocity_prop
+        assert np.all(test_read.current_prop == test.current_prop)
+        assert np.all(test_read.nested_prop["q1"] == test.nested_prop["q1"])
+        assert test_read.nested_prop["q2"] == test.nested_prop["q2"]
+        assert test_read.simple_prop == test.simple_prop
+        assert np.all(test_read.current_prop == test.current_prop)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #873

## Changes

Add `read_buffer_context` and `write_read_buffer_context` to `weldx.asdf.util`.

Update previous uses of `read_buffer` and `write_read_buffer` that inspect the result to use the context.

`read_buffer` and `write_read_buffer` were updated to use the new context to avoid code duplication. These were not removed to preserve the API and to leave them available for uses where the result is not inspected. Such as this test:
https://github.com/BAMWelDX/weldx/blob/c2ee9b1f7cb8df8b2f4723884341e9e20dcd0d50/weldx/tests/asdf_tests/test_asdf_base_types.py#L15-L20

## Related Issues

Closes #873

## Checks

- [ ] updated `CHANGELOG.md`
- [x] updated `tests/`
- [ ] ~updated `doc/`~
- [ ] ~update example/tutorial notebooks~
- [ ] ~update manifest file~
