### PR TITLE
fix pint 0.21 related errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.6.7 (unreleased)
+
+### Fixes
+
+- fix compatibility with `pint=0.21` \[{pull}`876`\] .
+
 ## 0.6.6 (19.04.2023)
 
 Version `0.6.6` is a compatibility release for `xarray>=2023.4.0` .

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -624,8 +624,8 @@ class ArcSegment(DynamicShapeSegment):
         self._radius = Q_(np.linalg.norm(diff.m), self._points.u)
 
         expr = "(x*cos(a+s*w)+y*sin(a+s*w))*r + o"
-        sign = -1 if np.cross([1, 0], diff) < 0 else 1
-        a = np.arccos(np.dot([1, 0], diff) / self._radius) * sign
+        sign = -1 if np.cross([1, 0], diff.m) < 0 else 1
+        a = np.arccos(np.dot([1, 0], diff.m) / self._radius.m) * sign
 
         params = dict(
             x=Q_([1, 0, 0], ""),

--- a/weldx/tests/_helpers.py
+++ b/weldx/tests/_helpers.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 import pint
+from pkg_resources import get_distribution
 
 from weldx.constants import Q_
 from weldx.geometry import _vector_is_close as vector_is_close
@@ -127,4 +128,9 @@ def matrix_is_close(mat_a, mat_b, abs_tol=1e-9) -> bool:
 
     if mat_a.shape != mat_b.shape:
         return False
-    return np.all(np.isclose(mat_a, mat_b, atol=abs_tol)).__bool__()
+
+    atol_unit = 1.0
+    if get_distribution("pint").version >= "0.21":
+        atol_unit = mat_b.u
+
+    return np.all(np.isclose(mat_a, mat_b, atol=abs_tol * atol_unit)).__bool__()

--- a/weldx/tests/_helpers.py
+++ b/weldx/tests/_helpers.py
@@ -130,7 +130,7 @@ def matrix_is_close(mat_a, mat_b, abs_tol=1e-9) -> bool:
         return False
 
     atol_unit = 1.0
-    if get_distribution("pint").version >= "0.21":
+    if isinstance(mat_b, pint.Quantity) and get_distribution("pint").version >= "0.21":
         atol_unit = mat_b.u
 
     return np.all(np.isclose(mat_a, mat_b, atol=abs_tol * atol_unit)).__bool__()

--- a/weldx/tests/transformations/_util.py
+++ b/weldx/tests/transformations/_util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Union
 
 import numpy as np
+from pkg_resources import get_distribution
 from xarray import DataArray
 
 import weldx.transformations as tf
@@ -77,7 +78,13 @@ def check_coordinate_system(
         lcs.orientation, orientation_expected, positive_orientation_expected
     )
 
-    assert np.allclose(lcs.coordinates.data, coordinates_expected, atol=1e-9)
+    atol_unit = 1.0
+    if get_distribution("pint").version >= "0.21":
+        atol_unit = coordinates_expected.u
+
+    assert np.allclose(
+        lcs.coordinates.data, coordinates_expected, atol=1e-9 * atol_unit
+    )
 
 
 def check_cs_close(lcs_0, lcs_1):


### PR DESCRIPTION
## Changes

- compatibility with `pint=0.21` and earlier versions
- add units to some newly supported `numpy` functions

## Related Issues

closes #872

## Checks

- [x] updated `CHANGELOG.md`
- [x] updated `tests/`
