### PR TITLE
pin pint<0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "xarray >=2022.9.0",
     "scipy >=1.6.2",
     "sympy >=1.6",
-    "pint >=0.18",
+    "pint >=0.18,<0.21",
     "pint-xarray >=0.3",
     "bottleneck >=1.3.3",
     "boltons",


### PR DESCRIPTION
## Changes

pin `pint<0.21`
The code changes required for pint 0.21 at runtime are easy enough to fix, however something seems to break our mypy pipeline.
See https://github.com/BAMWelDX/weldx/pull/876

## Related Issues

<!--
List related issues and closing issues here
-->

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
