### PR TITLE
update converters for pint 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - fix compatibility with `pint=0.21` \[{pull}`876`\].
+- fix typing compatibility with `pint=0.22` \[{pull}`880`\].
 - add `read_buffer_context` and `write_read_buffer_context` to `weldx.asdf.util`
   to fix tests accessing closed files. {issue}`873` \[{pull}`875`\].
 
@@ -16,6 +17,10 @@
 
 - removed keyword `dummy_inline_arrays` from function `asdf.util.write_buffer`
   as it was only used internally \[{pull}`875`\].
+
+### ASDF
+
+- update `PintQuantityConverter` and `PintUnitConverter` class assignments for `pint=0.22` \[{pull}`880`\].
 
 ## 0.6.6 (19.04.2023)
 

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -11,16 +11,17 @@ dependencies:
   - pint>=0.11
   - scipy>=1.6.2
   - sympy>=1.6
-  - asdf >=2.8
+  - asdf>=2.8
   - bottleneck>=1.3
   # notebook execution
   - myst-nb
   - ipykernel
   - ipywidgets<8
-  - weldx_widgets >=0.2.1
+  - weldx_widgets>=0.2.1
   # documentation
   - docutils>=0.19
   - sphinx>=4.1.1
+  - urllib3<2
   #- jinja2=3.0
   - sphinx-copybutton
   - pydata-sphinx-theme

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -66,8 +66,8 @@ U_.__doc__ = """For details on working with quantities and units, please see the
 """
 
 # set default units
-_DEFAULT_LEN_UNIT: pint.Unit = WELDX_UNIT_REGISTRY.millimeters
-_DEFAULT_ANG_UNIT: pint.Unit = WELDX_UNIT_REGISTRY.rad
+_DEFAULT_LEN_UNIT: pint.Unit = U_("millimeters")
+_DEFAULT_ANG_UNIT: pint.Unit = U_("rad")
 
 # set default unit registry for pint-xarray
 pint.set_application_registry(WELDX_UNIT_REGISTRY)

--- a/weldx/core/generic_series.py
+++ b/weldx/core/generic_series.py
@@ -852,7 +852,7 @@ class SeriesParameter:
     def units(self) -> pint.Unit:
         """Get the units information of the parameter."""
         if isinstance(self.values, pint.Quantity):
-            return self.values.units
+            return self.values.units  # type: ignore[return-value]
         return self.values.weldx.units
 
     @property
@@ -885,7 +885,7 @@ class SeriesParameter:
 def _quantity_to_coord_tuple(
     v: pint.Quantity, dim
 ) -> tuple[str, np.ndarray, dict[str, pint.Unit]]:
-    return dim, v.m, {UNITS_KEY: v.u}
+    return dim, v.m, {UNITS_KEY: v.u}  # type: ignore[dict-item]
 
 
 def _quantity_to_xarray(v: pint.Quantity, dim: str = None) -> xr.DataArray:

--- a/weldx/core/time_series.py
+++ b/weldx/core/time_series.py
@@ -239,8 +239,8 @@ class TimeSeries(TimeDependent):
     def _interp_time_expression(self, time: Time, time_unit: str) -> xr.DataArray:
         """Interpolate the time series if its data is a mathematical expression."""
         time_q = time.as_quantity(unit=time_unit)
-        if len(time_q.shape) == 0:
-            time_q = np.expand_dims(time_q, 0)  # type: ignore[assignment]
+        if len(time_q.m.shape) == 0:
+            time_q = np.expand_dims(time_q, 0)  # type: ignore[call-overload]
 
         time_xr = xr.DataArray(time_q, dims=["time"])
 

--- a/weldx/core/time_series.py
+++ b/weldx/core/time_series.py
@@ -240,7 +240,7 @@ class TimeSeries(TimeDependent):
         """Interpolate the time series if its data is a mathematical expression."""
         time_q = time.as_quantity(unit=time_unit)
         if len(time_q.m.shape) == 0:
-            time_q = np.expand_dims(time_q, 0)  # type: ignore[call-overload]
+            time_q = np.expand_dims(time_q, 0)  # type: ignore
 
         time_xr = xr.DataArray(time_q, dims=["time"])
 
@@ -430,7 +430,7 @@ class TimeSeries(TimeDependent):
 
         time = Time(self.time, self.reference_time).as_quantity()
         if time_unit is not None:
-            time = time.to(time_unit)
+            time = time.to(time_unit)  # type: ignore[assignment]
 
         axes.plot(time.m, self._data.data.m, **mpl_kwargs)  # type: ignore
         axes.set_xlabel(f"t in {time.u:~}")

--- a/weldx/tags/units/pint_quantity.py
+++ b/weldx/tags/units/pint_quantity.py
@@ -17,8 +17,14 @@ class PintQuantityConverter(WeldxConverter):
         "tag:stsci.edu:asdf/unit/quantity-1.*",
     ]
     types = [
-        "pint.util.Quantity",  # pint >= 0.20
-        "pint.quantity.build_quantity_class.<locals>.Quantity",  # pint < 0.20
+        # a type or string can be used here
+        # we use BOTH:
+        # - the type: to allow pint to freely move the Quantity class path
+        # - the string:
+        #     to support weldx.constants.Q_ which reports itself as a
+        #     'pint.Quantity'
+        pint.Quantity,
+        "pint.Quantity",
         "weldx.constants.Q_",
     ]
 
@@ -55,8 +61,10 @@ class PintUnitConverter(WeldxConverter):
 
     tags = ["asdf://weldx.bam.de/weldx/tags/units/units-0.1.*"]
     types = [
-        "pint.util.Unit",  # pint >= 0.20
-        "pint.unit.build_unit_class.<locals>.Unit",  # pint < 0.20
+        # we need both the type and string (see the description
+        # about pint.Quantity in the PintQuantityConverter above)
+        pint.Unit,
+        "pint.Unit",
         "weldx.constants.U_",
     ]
 

--- a/weldx/time.py
+++ b/weldx/time.py
@@ -428,9 +428,7 @@ class Time:
             return False
         return np.allclose(self.as_quantity("s").m, other.as_quantity("s").m)
 
-    def as_quantity(
-        self, unit: str = "s"
-    ) -> Union[pint.Quantity, pint.facets.plain.quantity.PlainQuantity]:
+    def as_quantity(self, unit: str = "s") -> pint.Quantity:
         """Return the data as `pint.Quantity`.
 
         Parameters
@@ -455,7 +453,7 @@ class Time:
         if self.is_absolute:
             # store time_ref info
             q.time_ref = self.reference_time  # type: ignore[attr-defined]
-        return q
+        return q  # type: ignore[return-value]
 
     def as_timedelta(self) -> Union[Timedelta, TimedeltaIndex]:
         """Return the data as `pandas.TimedeltaIndex` or `pandas.Timedelta`."""

--- a/weldx/time.py
+++ b/weldx/time.py
@@ -426,9 +426,11 @@ class Time:
         other = Time(other)
         if self.reference_time != other.reference_time:
             return False
-        return np.allclose(self.as_quantity(), other.as_quantity())
+        return np.allclose(self.as_quantity("s").m, other.as_quantity("s").m)
 
-    def as_quantity(self, unit: str = "s") -> pint.Quantity:
+    def as_quantity(
+        self, unit: str = "s"
+    ) -> Union[pint.Quantity, pint.facets.plain.quantity.PlainQuantity]:
         """Return the data as `pint.Quantity`.
 
         Parameters
@@ -574,7 +576,7 @@ class Time:
         `Time.as_quantity`
 
         """
-        return self.as_quantity(unit="s")
+        return self.as_quantity(unit="s")  # type: ignore[return-value]
 
     @property
     def duration(self) -> Time:

--- a/weldx/transformations/rotation.py
+++ b/weldx/transformations/rotation.py
@@ -68,12 +68,12 @@ class WXRotation(_Rotation):
         """
         if isinstance(angles, pint.Quantity):
             if angles.u == U_(""):
-                angles = angles.to("rad")
+                angles.ito("rad")
             degrees = "rad" not in str(angles.u)
             if degrees:
-                angles = angles.to("degree")
+                angles.ito("degree")
             else:
-                angles = angles.to("rad")
+                angles.ito("rad")
             angles = angles.m
 
         rot = super().from_euler(seq=seq, angles=angles, degrees=degrees)

--- a/weldx/transformations/rotation.py
+++ b/weldx/transformations/rotation.py
@@ -68,12 +68,12 @@ class WXRotation(_Rotation):
         """
         if isinstance(angles, pint.Quantity):
             if angles.u == U_(""):
-                angles.ito("rad")
+                angles = angles.to("rad")  # type: ignore[assignment]
             degrees = "rad" not in str(angles.u)
             if degrees:
-                angles.ito("degree")
+                angles = angles.to("degree")  # type: ignore[assignment]
             else:
-                angles.ito("rad")
+                angles = angles.to("rad")  # type: ignore[assignment]
             angles = angles.m
 
         rot = super().from_euler(seq=seq, angles=angles, degrees=degrees)

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -243,7 +243,9 @@ def _coordinates_from_quantities(
 ) -> dict[str, tuple[str, np.ndarray, dict[str, pint.Unit]]]:
     """Create a dict with unit information that can be passed as coords for xarray."""
     return {
-        k: (k, v.m, {UNITS_KEY: v.u}) if isinstance(v, pint.Quantity) else v
+        k: (k, v.m, {UNITS_KEY: v.u})  # type: ignore[dict-item]
+        if isinstance(v, pint.Quantity)
+        else v
         for k, v in q_dict.items()
     }
 


### PR DESCRIPTION
in pint 0.22 Quantity appears at pint.registry.Quantity and requires an update to the corresponding asdf
Converter (the same for pint.registry.Unit).

## Changes

I opted to add the type `pint.Quantity` to the types supported by `PintQuantityConverter`. Types and/or strings can be used here and both have pros/cons. Using the type requires that pint be imported when the `Converter` is created (which can slow down initialization while asdf loads extensions. However this doesn't appear to be an issue here as pint is already imported when `weldx.tags.units.pint_quantity` is imported. By using the type, pint is free to move the internal implementation of Quantity (which can change the class path) but as long as it appears importable via `pint.Quanity` the Converter should stay up-to-date.

In this case the string `"pint.Quantity"` also needs to be included as `weldx.constants.Q_` appears as a `"pint.Quantity"` when asdf inspects instances of `weldx.constants.Q_` (as inspected with [`asdf.util.get_class_name`](https://github.com/asdf-format/asdf/blob/b0c9a50e8d3add337e1271369a3bf834925176a4/asdf/util.py#L321)).

I added some comments with a shorter version of the above description. 


## Related Issues

Fixes #879 

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
