### PR TITLE
import ValidationError from asdf.exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### ASDF
 
 - update `PintQuantityConverter` and `PintUnitConverter` class assignments for `pint=0.22` \[{pull}`880`\].
+- use `ValidationError` from `asdf` instead of `jsonschema` \[{pull}`886`\].
 
 ## 0.6.6 (19.04.2023)
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -279,7 +279,6 @@ def _get_intersphinx_mapping():
         # "dask": ("https://docs.dask.org/en/latest", None),
         # "numba": ("https://numba.pydata.org/numba-doc/latest", None),
         "pint": (f"https://pint.readthedocs.io/en/{pint_version}", None),
-        "jsonschema": ("https://python-jsonschema.readthedocs.io/en/stable/", None),
         "asdf": (f"https://asdf.readthedocs.io/en/{asdf_version}/", None),
         "networkx": ("https://networkx.org/documentation/stable/", None),
         "IPython": ("https://ipython.readthedocs.io/en/stable/", None),

--- a/doc/src/tutorials/quality_standards.ipynb
+++ b/doc/src/tutorials/quality_standards.ipynb
@@ -505,7 +505,7 @@
    "source": [
     "try:\n",
     "    WeldxFile(tree={\"equipment\": my_equipment}, mode=\"rw\")\n",
-    "except asdf.ValidationError:\n",
+    "except asdf.exceptions.ValidationError:\n",
     "    print(\"Ups..., got some lengthy validation error...\")\n",
     "else:\n",
     "    raise Exception(\"Expected exception not raised\")"
@@ -543,7 +543,7 @@
     "\n",
     "try:\n",
     "    WeldxFile(tree={\"equipment\": my_equipment}, mode=\"rw\")\n",
-    "except asdf.ValidationError:\n",
+    "except asdf.exceptions.ValidationError:\n",
     "    print(\"Still getting a validation error...\")\n",
     "else:\n",
     "    raise Exception(\"Expected exception not raised\")"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "numpy >=1.20",
-    "asdf >=2.15.0",
+    "asdf >=2.15.1",
     "pandas >=1.0",
     "xarray >=2022.9.0",
     "scipy >=1.6.2",

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -14,11 +14,10 @@ import asdf
 import numpy as np
 from asdf import AsdfFile, config_context, generic_io
 from asdf import open as open_asdf
-from asdf.exceptions import AsdfWarning
+from asdf.exceptions import AsdfWarning, ValidationError
 from asdf.tags.core import Software
 from asdf.util import FileType, get_file_type
 from boltons.iterutils import get_path
-from jsonschema import ValidationError
 
 from weldx.asdf.util import (
     _ProtectedViewDict,

--- a/weldx/asdf/validators.py
+++ b/weldx/asdf/validators.py
@@ -45,7 +45,7 @@ def _walk_validator(
 
     Yields
     ------
-    asdf.ValidationError
+    asdf.exceptions.ValidationError
 
     """
     if position is None:  # pragma: no cover
@@ -90,7 +90,7 @@ def _unit_validator(
 
     Yields
     ------
-    asdf.ValidationError
+    asdf.exceptions.ValidationError
 
     """
     if not position:

--- a/weldx/tests/asdf_tests/installable_quality_standard_check.py
+++ b/weldx/tests/asdf_tests/installable_quality_standard_check.py
@@ -1,5 +1,5 @@
 import pytest
-from asdf import ValidationError
+from asdf.exceptions import ValidationError
 
 from weldx import WeldxFile
 from weldx.config import enable_quality_standard

--- a/weldx/tests/asdf_tests/quality_standards_check.py
+++ b/weldx/tests/asdf_tests/quality_standards_check.py
@@ -74,7 +74,7 @@ def test_quality_standards():
 
     # run tests
     eq = MeasurementEquipment("some_equipment")
-    with pytest.raises(asdf.ValidationError):
+    with pytest.raises(asdf.exceptions.ValidationError):
         WeldxFile(tree={"equipment": eq}, mode="rw")
 
     eq.wx_metadata = {"required_field_for_test": 1234}

--- a/weldx/tests/asdf_tests/test_asdf_base_types.py
+++ b/weldx/tests/asdf_tests/test_asdf_base_types.py
@@ -4,7 +4,7 @@ import uuid
 import numpy as np
 import pytest
 import xarray as xr
-from asdf import ValidationError
+from asdf.exceptions import ValidationError
 
 from weldx.asdf.util import write_read_buffer, write_read_buffer_context
 

--- a/weldx/tests/asdf_tests/test_asdf_core.py
+++ b/weldx/tests/asdf_tests/test_asdf_core.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from asdf import ValidationError
+from asdf.exceptions import ValidationError
 from fs.memoryfs import MemoryFS
 from fs.osfs import OSFS
 from scipy.spatial.transform import Rotation

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -7,10 +7,10 @@ import tempfile
 from io import BytesIO
 
 import asdf
+from asdf.exceptions import ValidationError
 import numpy as np
 import pytest
 import xarray as xr
-from jsonschema import ValidationError
 
 from weldx.asdf.cli.welding_schema import single_pass_weld_example
 from weldx.asdf.file import _PROTECTED_KEYS, DEFAULT_ARRAY_INLINE_THRESHOLD, WeldxFile

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -7,10 +7,10 @@ import tempfile
 from io import BytesIO
 
 import asdf
-from asdf.exceptions import ValidationError
 import numpy as np
 import pytest
 import xarray as xr
+from asdf.exceptions import ValidationError
 
 from weldx.asdf.cli.welding_schema import single_pass_weld_example
 from weldx.asdf.file import _PROTECTED_KEYS, DEFAULT_ARRAY_INLINE_THRESHOLD, WeldxFile

--- a/weldx/tests/test_config.py
+++ b/weldx/tests/test_config.py
@@ -72,7 +72,7 @@ class TestConfig:
 
         ge = MeasurementEquipment(name="GE")
         if expect_validation_error:
-            with pytest.raises(asdf.ValidationError):
+            with pytest.raises(asdf.exceptions.ValidationError):
                 WeldxFile(tree={"equipment": ge}, mode="rw")
         else:
             WeldxFile(tree={"equipment": ge}, mode="rw")


### PR DESCRIPTION
## Changes

asdf has recently run into compatibility issues with jsonschema 4.18+. The newer versions of jsonschema dropped support for a feature required in asdf which left us with little choice but to vendorize jsonschema. This presented an opportunity to clean up some leaky bits of the asdf API including the issue that `jsonschema.ValidationError` was transparently passed to user code and libraries (like weldx) had to import `ValidationError` from jsonschema.

asdf 2.15 introduced `ValidationError` as part of the public api available at `asdf.exceptions.ValidationError`. The changes in this PR modify a few tests and docs to import `ValidationError` from `asdf.exceptions` (instead of jsonschema or from the top level asdf module).

asdf 2.15.1 includes the vendorized jsonschema, keeps jsonschema as a dependency and attempts to use the exceptions from the installed jsonschema (to not break some downstream libraries that use asdf). We are planning to drop jsonschema as a dependency and stop using it's exceptions in asdf 3.0 (or possibly in 2.15.2 if further changes to jsonschema make it's exceptions incompatible).

Please see the [What's New](https://asdf.readthedocs.io/en/latest/asdf/whats_new.html#jsonschema) page in the asdf 2.15.1 docs for more information and let me know if you have any questions, comments or concerns.

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
