### PR TITLE
fix test that relied on slow garbage collection

### DIFF
--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -449,7 +449,8 @@ properties:
             # pytest increases memory a bit, but not as much as our large array would
             # occupy in memory.
             assert diff <= large_array.nbytes * 1.1, diff / 1024**2
-        assert np.all(WeldxFile(fn)["x"] == large_array)
+        with WeldxFile(fn) as wf:
+            assert np.all(wf["x"] == large_array)
 
     @staticmethod
     @pytest.mark.parametrize("mode", ("r", "rw"))


### PR DESCRIPTION
## Changes

This PR makes a small change to `TestWeldXFile.test_show_header_memory_usage` to keep the opened `WeldxFile` in memory while the assert is computed.

Without this PR the test includes:
https://github.com/BAMWelDX/weldx/blob/bb213a77ee79e8c982adfec0d56b9d5a3efee7b1/weldx/tests/asdf_tests/test_weldx_file.py#L452

Breaking apart the above line the following steps occur:
1) a `WeldxFile` object is instantiated using `fn` as the input
2) the `x` value is extracted from the `WeldxFile`
3) the contents of `x` are compared against `large_array`
4) etc...

If garbage collection is triggered between 2 and 3 above (after `x` is extracted but before the comparison with `large_array`) there is no reference keeping `WeldxFile` in memory (and keeping the underlying asdf file open). The garbage collector is therefore free to close the asdf file and cause the comparison to fail (because the contents of `x` have not yet been read since this is a lazy-loaded array).

This PR updates the test to use a with context to keep the `WeldxFile` open.

An example of where this test fails can be seen here: https://github.com/asdf-format/asdf/actions/runs/7390148220/job/20104458462?pr=1721 (Note that this is a CI run for changes to asdf tree traversal algorithms. I cannot say definitively but I have the suspicion that the current asdf tree algorithms produce difficult-to-collect structures. This might be resulting in objects surviving a few generations of collection. This would explain why the issue fixed in this PR is not yet causing test failures).

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
