### PR TITLE
fix WeldxFile doctest for asdf 3.0

### DIFF
--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -193,13 +193,10 @@ class WeldxFile(_ProtectedViewDict):
     %YAML 1.1
     %TAG ! tag:stsci.edu:asdf/
     --- !core/asdf-1.1.0
-    asdf_library: !core/software-1.0.0 {...
-      name: asdf, version: ...}
+    asdf_library: !core/software-1.0.0 ...
     history:
       extensions:
-      - !core/extension_metadata-1.0.0
-        extension_class: asdf.extension.BuiltinExtension
-        software: !core/software-1.0.0 {name: asdf, version: ...}
+      ...
     name: CXCOMP
     value: 42
     <BLANKLINE>


### PR DESCRIPTION
## Changes

As mentioned in https://github.com/BAMWelDX/weldx/pull/903

A doctest is failing due to changes in asdf 3.0 (including removal of `BuiltinExtension`) that result in slight and otherwise inconsequential header differences.

This PR expands the use of `...` in the doctest to allow the text matching to ignore these header differences.

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
