### PR TITLE
Schema updates for current and upcoming asdf changes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         py: ['3.9', '3.10', '3.11', '3.12']
+        asdf: ['4']
+        include:
+          - os: ubuntu-latest
+            py: '3.10'
+            asdf: 3
+          - os: ubuntu-latest
+            py: '3.10'
+            asdf: 2
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,6 +67,7 @@ jobs:
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           create-args: >-
             python=${{ matrix.py }}
+            asdf=${{ matrix.asdf }}
             wheel
             pip
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,7 +98,7 @@ jobs:
           pytest -n 2 --runslow --junit-xml pytest.xml
 
       - name: Upload Test Results
-        if: always() && (matrix.py == '3.10')
+        if: always() && (matrix.py == '3.10') && (matrix.asdf == 4)
         uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 0.7.0 (unreleased)
+
+### Dependencies
+
+- remove upper pin for `asdf` \[{pull}`910`\].
+
+### ASDF
+
+- update schemas for upcoming ASDF standard 1.6.0 \[{pull}`910`\].
+
+# Release Notes
+
 ## 0.6.9 (19.11.2024)
 
 ### Changes
@@ -55,7 +67,6 @@
 
 - update `PintQuantityConverter` and `PintUnitConverter` class assignments for `pint=0.22` \[{pull}`880`\].
 - use `ValidationError` from `asdf` instead of `jsonschema` \[{pull}`886`\].
-- update schemas for upcoming ASDF standard 1.6.0 \[{pull}`910`\].
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 - update `PintQuantityConverter` and `PintUnitConverter` class assignments for `pint=0.22` \[{pull}`880`\].
 - use `ValidationError` from `asdf` instead of `jsonschema` \[{pull}`886`\].
+- update schemas for upcoming ASDF standard 1.6.0 \[{pull}`910`\].
 
 ### Dependencies
 

--- a/devtools/scripts/update_manifest.py
+++ b/devtools/scripts/update_manifest.py
@@ -14,7 +14,7 @@ from weldx.asdf.util import get_converter_for_tag
 
 def update_manifest(
     search_dir: str = "../../weldx/schemas",
-    out: str = f"../../weldx/manifests/weldx-{WELDX_EXTENSION_VERSION}.yaml",
+    out: str = f"../../weldx/extensions/weldx-{WELDX_EXTENSION_VERSION}.yaml",
 ):
     """Create manifest file from existing schemas."""
     # read existing manifest

--- a/devtools/scripts/update_manifest.py
+++ b/devtools/scripts/update_manifest.py
@@ -14,7 +14,7 @@ from weldx.asdf.util import get_converter_for_tag
 
 def update_manifest(
     search_dir: str = "../../weldx/schemas",
-    out: str = f"../../weldx/extensions/weldx-{WELDX_EXTENSION_VERSION}.yaml",
+    out: str = f"../../weldx/manifests/weldx-{WELDX_EXTENSION_VERSION}.yaml",
 ):
     """Create manifest file from existing schemas."""
     # read existing manifest
@@ -23,7 +23,7 @@ def update_manifest(
         Loader=yaml.SafeLoader,
     )
 
-    manifest["id"] = WELDX_MANIFEST_URI
+    manifest["id"] = WELDX_EXTENSION_URI
     manifest["extension_uri"] = WELDX_EXTENSION_URI
 
     # keep only ASDF schema mappings

--- a/devtools/scripts/update_manifest.py
+++ b/devtools/scripts/update_manifest.py
@@ -7,7 +7,6 @@ import yaml
 from weldx.asdf.constants import (
     WELDX_EXTENSION_URI,
     WELDX_EXTENSION_VERSION,
-    WELDX_MANIFEST_URI,
 )
 from weldx.asdf.util import get_converter_for_tag
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dynamic = [
   "version", # version gets derived from git by setuptools_scm.
 ]
 dependencies = [
-  "asdf>=2.15.1,<4",
+  "asdf>=2.15.1",
   "bidict",
   "boltons",
   "bottleneck>=1.3.3",

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -386,6 +386,11 @@ class WeldxFile(_ProtectedViewDict):
         # 2. file exists, but should be updated with new tree
         if created:
             asdf_file = asdf.AsdfFile(tree=tree, **asdffile_kwargs)
+            if asdf.__version__ >= "4.0.0":
+                # Starting in asdf 4 passing a tree to AsdfFile will
+                # not automatically validate the tree. For those versions
+                # we call validate here to check the tree.
+                asdf_file.validate()
             with self._config_context():
                 asdf_file.write_to(filename_or_path_like, **write_kwargs)
             # Now set the file handle to the newly created AsdfFile instance.

--- a/weldx/asdf/file.py
+++ b/weldx/asdf/file.py
@@ -202,7 +202,7 @@ class WeldxFile(_ProtectedViewDict):
 
     >>> wx2.header()  # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
     #ASDF 1.0.0
-    #ASDF_STANDARD 1.5.0
+    #ASDF_STANDARD ...
     %YAML 1.1
     %TAG ! tag:stsci.edu:asdf/
     --- !core/asdf-1.1.0

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import functools
 import re
 
-from asdf.asdf import SerializationContext
+import asdf
+
+if asdf.__version__ >= "3.0.0":
+    from asdf.extension import SerializationContext
+else:
+    from asdf.asdf import SerializationContext
 from asdf.extension import Converter
 from asdf.versioning import AsdfSpec
 from boltons.iterutils import remap

--- a/weldx/asdf/types.py
+++ b/weldx/asdf/types.py
@@ -10,7 +10,6 @@ if asdf.__version__ >= "3.0.0":
 else:
     from asdf.asdf import SerializationContext
 from asdf.extension import Converter
-from asdf.versioning import AsdfSpec
 from boltons.iterutils import remap
 
 from weldx.constants import META_ATTR, USER_ATTR
@@ -121,8 +120,5 @@ def format_tag(tag_name, version=None, organization="weldx.bam.de", standard="we
 
     if version is None:
         return tag
-
-    if isinstance(version, AsdfSpec):
-        version = str(version.spec)
 
     return f"{tag}-{version}"

--- a/weldx/asdf/util.py
+++ b/weldx/asdf/util.py
@@ -12,7 +12,11 @@ from warnings import warn
 
 import asdf
 import pint
-from asdf.asdf import SerializationContext
+
+if asdf.__version__ >= "3.0.0":
+    from asdf.extension import SerializationContext
+else:
+    from asdf.asdf import SerializationContext
 from asdf.config import AsdfConfig, get_config
 from asdf.extension import Extension
 from asdf.tagged import TaggedDict, TaggedList, TaggedString
@@ -502,7 +506,7 @@ def dataclass_serialization_class(
 
 def get_weldx_extension(ctx: SerializationContext | AsdfConfig) -> Extension:
     """Grab the weldx extension from list of current active extensions."""
-    if isinstance(ctx, asdf.asdf.SerializationContext):
+    if isinstance(ctx, SerializationContext):
         extensions = ctx.extension_manager.extensions
     elif isinstance(ctx, asdf.config.AsdfConfig):
         extensions = ctx.extensions

--- a/weldx/manifests/weldx-0.1.0.yaml
+++ b/weldx/manifests/weldx-0.1.0.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-id: asdf://weldx.bam.de/weldx/manifests/weldx-0.1.0
+id: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.0
 extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.0
 title: weldx extension manifest for tag mapping
 description: Manifest listing all tag URIs with schema URIs supported by weldx

--- a/weldx/manifests/weldx-0.1.1.yaml
+++ b/weldx/manifests/weldx-0.1.1.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-id: asdf://weldx.bam.de/weldx/manifests/weldx-0.1.1
+id: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.1
 extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.1
 title: weldx extension manifest for tag mapping
 description: Manifest listing all tag URIs with schema URIs supported by weldx

--- a/weldx/manifests/weldx-0.1.2.yaml
+++ b/weldx/manifests/weldx-0.1.2.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 ---
-id: asdf://weldx.bam.de/weldx/manifests/weldx-0.1.2
+id: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.2
 extension_uri: asdf://weldx.bam.de/weldx/extensions/weldx-0.1.2
 title: weldx extension manifest for tag mapping
 description: Manifest listing all tag URIs with schema URIs supported by weldx

--- a/weldx/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-0.1.0.yaml
@@ -11,6 +11,7 @@ description: |
 examples:
   -
     - A simple `SpatialData` with triangulation
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.0>
         coordinates: !core/ndarray-1.0.0

--- a/weldx/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/geometry/spatial_data-0.1.1.yaml
@@ -12,6 +12,7 @@ description: |
 examples:
   -
     - A simple `SpatialData` with triangulation
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.1>
         coordinates: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0>
@@ -32,6 +33,7 @@ examples:
           shape: [2, 3]
   -
     - A `SpatialData` object with data in three dimensions
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/geometry/spatial_data-0.1.1>
         coordinates: !<asdf://weldx.bam.de/weldx/tags/core/data_array-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.0.yaml
@@ -17,6 +17,7 @@ examples:
         value: 10.0
   -
     - A time_series describing a sine oscillation in 3d space along the z-axis
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.0>
         expression: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/time_series-0.1.1.yaml
@@ -17,6 +17,7 @@ examples:
         value: 10.0
   -
     - A time series of 4 discrete points
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>
         values: !core/ndarray-1.0.0
@@ -33,6 +34,7 @@ examples:
         interpolation: step
   -
     - A time_series describing a sine oscillation in 3d space along the z-axis
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/time_series-0.1.1>
         expression: !<asdf://weldx.bam.de/weldx/tags/core/mathematical_expression-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-0.1.0.yaml
@@ -11,6 +11,7 @@ description: |
 examples:
   -
     - A constant transformation describing a translation of 1 mm into the z direction
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
         coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
@@ -26,6 +27,7 @@ examples:
     - |
       A time dependent transformation describing a linear movement from 5 mm to 295 mm
       over 20 seconds along the x-axis direction.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
         time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
@@ -50,6 +52,7 @@ examples:
             shape: [2, 3]
   -
     - A static transformation describing an euler rotation of 45 degree around the x-axis.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
         orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
@@ -67,6 +70,7 @@ examples:
     - |
       A time dependent transformation describing an euler rotation around the y-axis from 0 degree to 120 degree
       over 20 seconds.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>
         time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/transformations/local_coordinate_system-0.1.1.yaml
@@ -11,6 +11,7 @@ description: |
 examples:
   -
     - A constant transformation describing a translation of 1 mm into the z direction
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.1>
         coordinates: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
@@ -26,6 +27,7 @@ examples:
     - |
       A time dependent transformation describing a linear movement from 5 mm to 295 mm
       over 20 seconds along the x-axis direction.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.1>
         time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
@@ -50,6 +52,7 @@ examples:
             shape: [2, 3]
   -
     - A static transformation describing an euler rotation of 45 degree around the x-axis.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.1>
         orientations: !<asdf://weldx.bam.de/weldx/tags/core/variable-0.1.0>
@@ -67,6 +70,7 @@ examples:
     - |
       A time dependent transformation describing an euler rotation around the y-axis from 0 degree to 120 degree
       over 20 seconds.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.1>
         time: !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/core/transformations/rotation-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/core/transformations/rotation-0.1.0.yaml
@@ -11,6 +11,7 @@ description: |
 examples:
   -
     - A "xyz" euler rotation with 10, 20 and 60 degree angles as euler representation.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.0>
         angles: !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0>
@@ -22,6 +23,7 @@ examples:
         sequence: xyz
   -
     - The quaternion rotation representation
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.0>
         quaternions: !core/ndarray-1.0.0
@@ -30,6 +32,7 @@ examples:
           shape: [4]
   -
     - The matrix rotation representation.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.0>
         matrix: !core/ndarray-1.0.0
@@ -41,6 +44,7 @@ examples:
           shape: [3, 3]
   -
     - The rotation vector representation.
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/core/transformations/rotation-0.1.0>
         rotvec: !core/ndarray-1.0.0

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/multi_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/multi_pass_weld-0.1.0.yaml
@@ -66,6 +66,7 @@ properties:
 examples:
   -
     - Two seams with a single layer and bead, but the first seam has two weldments while the second has only one.
+    - asdf-standard-1.5.0
     - |
       !<tag:stsci.edu:asdf/core/asdf-1.1.0>
         weld_seam:

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/multi_pass_weld-0.1.1.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/multi_pass_weld-0.1.1.yaml
@@ -67,6 +67,7 @@ required: [weld_seam]
 examples:
   -
     - Two seams with a single layer and bead, but the first seam has two weldments while the second has only one.
+    - asdf-standard-1.5.0
     - |
       !<tag:stsci.edu:asdf/core/asdf-1.1.0>
         weld_seam:

--- a/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/datamodels/single_pass_weld-0.1.0.yaml
@@ -117,6 +117,7 @@ required: [process, equipment, workpiece, measurements, welding_current, welding
 examples:
   -
     - A simple welding application
+    - asdf-standard-1.5.0
     - |
       !<tag:stsci.edu:asdf/core/asdf-1.1.0>
         TCP: !<asdf://weldx.bam.de/weldx/tags/core/transformations/local_coordinate_system-0.1.0>

--- a/weldx/schemas/weldx.bam.de/weldx/groove/terms-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/groove/terms-0.1.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://weldx.bam.de/weldx/schemas/groove/iso_9692_1_2013_12/terms-0.1.0"
+id: "asdf://weldx.bam.de/weldx/schemas/groove/terms-0.1.0"
 
 title: |
   DIN EN ISO 9692-1 definitions

--- a/weldx/schemas/weldx.bam.de/weldx/process/GMAW-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/process/GMAW-0.1.0.yaml
@@ -34,6 +34,7 @@ examples:
           tag: CLOOS/pulse
   -
     - A spray arc process where the voltage decreases linearly from 40 V to 20 V over 10 s
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/process/CLOOS/spray_arc-0.1.0>
         base_process: spray

--- a/weldx/schemas/weldx.bam.de/weldx/time/timedeltaindex-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/time/timedeltaindex-0.1.0.yaml
@@ -18,6 +18,7 @@ examples:
         max: !<asdf://weldx.bam.de/weldx/tags/time/timedelta-0.1.0> P0DT0H0M10S
   -
     - An irregular timedeltaindex representing timestamps at 0 s, 4 s, 6 s and 10 s
+    - asdf-standard-1.5.0
     - |
       !<asdf://weldx.bam.de/weldx/tags/time/timedeltaindex-0.1.0>
         values: !core/ndarray-1.0.0

--- a/weldx/schemas/weldx.bam.de/weldx/units/quantity-0.1.0.yaml
+++ b/weldx/schemas/weldx.bam.de/weldx/units/quantity-0.1.0.yaml
@@ -18,12 +18,14 @@ examples:
           units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> kilometer
   -
     - A quantity with an array of values
+    - asdf-standard-1.5.0
     - |
         !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0>
           value: !core/ndarray-1.0.0 [1, 2, 3, 4]
           units: !<asdf://weldx.bam.de/weldx/tags/units/units-0.1.0> ampere
   -
     - A quantity with an n-dimensional array of values
+    - asdf-standard-1.5.0
     - |
         !<asdf://weldx.bam.de/weldx/tags/units/quantity-0.1.0>
           value: !core/ndarray-1.0.0

--- a/weldx/tags/base_types.py
+++ b/weldx/tags/base_types.py
@@ -2,7 +2,12 @@
 
 from uuid import UUID
 
-from asdf.asdf import SerializationContext
+import asdf
+
+if asdf.__version__ >= "3.0.0":
+    from asdf.extension import SerializationContext
+else:
+    from asdf.asdf import SerializationContext
 
 from weldx.asdf.types import WeldxConverter
 


### PR DESCRIPTION
## Changes

asdf is working on making the current development version of the ASDF standard (1.6.0) stable (see https://github.com/asdf-format/asdf/pull/1744 for details). As the 1.6.0 version contains new versions of a few core schemas (including [ndarray](https://github.com/asdf-format/asdf-standard/blob/main/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml)). This PR updates the weldx schemas for these upcoming changes (and applies a few other related fixes).

- update schema examples that use `ndarray-1.0.0` adding a `asdf-standard` requirement to force these examples to use ASDF standard 1.5.0 (where `ndarray-1.0.0` exists)
- update schema "id"s to match "uri"s used to register the schemas with asdf
- update manifest generation script to use the uri prefix used to register the manifests (see below)

For the manifests, the `id` in the files follow the form `.../weldx/manifests/...`
https://github.com/BAMWelDX/weldx/blob/2bceb68405385229190cb00bb71dec95e941bed9/weldx/manifests/weldx-0.1.2.yaml#L3
However these files are registered:
https://github.com/BAMWelDX/weldx/blob/2bceb68405385229190cb00bb71dec95e941bed9/weldx/asdf/extension.py#L27-L33
using the `WELDX_EXTENSION_URI_BASE` uri prefix:
https://github.com/BAMWelDX/weldx/blob/2bceb68405385229190cb00bb71dec95e941bed9/weldx/asdf/constants.py#L9
which uses `.../weldx/extensions`. This means that these manifest resources are available (via the asdf `resource_manager`) using `../weldx/extensions/...` uris yet have ids with `.../weldx/manifests/`

```python
>> import asdf
>> manifest = asdf.schema.load_schema("asdf://weldx.bam.de/weldx/extensions/weldx-0.1.2")
>> manifest['id']
asdf://weldx.bam.de/weldx/manifests/weldx-0.1.2
```
This PR changes the `id`s to match the `uri`s.

This PR also updates `SerializationContext` imports to use `asdf.extension` for asdf version >= 3.0.0 to avoid `DeprecationWarning` messages form importing `asdf.asdf` and `SerializationContext` from `asdf.asdf`.

## Related Issues

Fixes #900 

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
