### PR TITLE
use pandas.to_timedelta function instead of invoking deprecated ctor arg

### DIFF
--- a/weldx/tests/transformations/test_cs_manager.py
+++ b/weldx/tests/transformations/test_cs_manager.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from pandas import TimedeltaIndex as TDI
 from pandas import Timestamp as TS
 
 import weldx.transformations as tf
@@ -953,7 +952,7 @@ def test_time_union_time_series_coords(
         )
 
     if exp_time is not None:
-        exp_time = TDI(exp_time, unit="s")
+        exp_time = pd.to_timedelta(exp_time, unit="s")
     assert np.all(exp_time == csm.time_union(list_of_edges))
 
 
@@ -1378,19 +1377,19 @@ def test_get_local_coordinate_system_time_dep(
     time_refs = [t if t is None else pd.Timestamp(t) for t in time_refs]
 
     # moves in positive x-direction
-    time_1 = TDI([0, 3, 12], "D")
+    time_1 = pd.to_timedelta([0, 3, 12], "D")
     time_ref_1 = time_refs[1]
     orientation_1 = None
     coordinates_1 = Q_([[i, 0, 0] for i in [0, 0.25, 1]], "mm")
 
     # moves in negative x-direction and rotates positively around the x-axis
-    time_2 = TDI([0, 4, 8, 12], "D")
+    time_2 = pd.to_timedelta([0, 4, 8, 12], "D")
     time_ref_2 = time_refs[2]
     coordinates_2 = Q_([[-i, 0, 0] for i in [0, 1 / 3, 2 / 3, 1]], "mm")
     orientation_2 = r_mat_x([0, 2 / 3, 4 / 3, 2])
 
     # rotates negatively around the x-axis
-    time_3 = TDI([0, 3, 6, 9, 12], "D")
+    time_3 = pd.to_timedelta([0, 3, 6, 9, 12], "D")
     time_ref_3 = time_refs[3]
     coordinates_3 = Q_([1, 0, 0], "mm")
     orientation_3 = r_mat_x([0, -0.5, -1, -1.5, -2])
@@ -1523,8 +1522,8 @@ def test_get_local_coordinate_system_exceptions(
 
     """
     # setup
-    time_1 = TDI([0, 3], "D")
-    time_2 = TDI([4, 7], "D")
+    time_1 = pd.to_timedelta([0, 3], "D")
+    time_2 = pd.to_timedelta([4, 7], "D")
 
     csm = tf.CoordinateSystemManager(root_coordinate_system_name="root")
     csm.create_cs("cs_1", "root", r_mat_z(0.5), Q_([1, 2, 3], "mm"))
@@ -1691,7 +1690,7 @@ def test_merge_reference_times(
     # setup
     lcs_static = tf.LocalCoordinateSystem(coordinates=Q_([1, 1, 1], "mm"))
     lcs_dynamic = tf.LocalCoordinateSystem(
-        coordinates=Q_([[0, 4, 2], [7, 2, 4]], "mm"), time=TDI([4, 8], "D")
+        coordinates=Q_([[0, 4, 2], [7, 2, 4]], "mm"), time=pd.to_timedelta([4, 8], "D")
     )
     time_ref_parent = None
     if time_ref_day_parent is not None:
@@ -2532,18 +2531,18 @@ def _coordinates_from_value(val, clip_min=None, clip_max=None):
 @pytest.mark.parametrize(
     "time, time_ref, systems, csm_has_time_ref, num_abs_systems",
     [
-        (TDI([1, 7, 11, 20], "D"), None, None, False, 0),
-        (TDI([3], "D"), None, None, False, 0),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), None, None, False, 0),
+        (pd.to_timedelta([3], "D"), None, None, False, 0),
         (pd.Timedelta(3, "D"), None, None, False, 0),
         (Q_([1, 7, 11, 20], "days"), None, None, False, 0),
         (["5days", "8days"], None, None, False, 0),
-        (TDI([1, 7, 11, 20], "D"), None, ["lcs_1"], False, 0),
-        (TDI([1, 7, 11, 20], "D"), None, ["lcs_1", "lcs_2"], False, 0),
-        (TDI([1, 7, 11, 20], "D"), "2000-01-10", None, True, 0),
-        (TDI([1, 7, 11, 20], "D"), "2000-01-13", None, True, 0),
-        (TDI([1, 7, 11, 20], "D"), "2000-01-13", None, False, 3),
-        (TDI([1, 7, 11, 20], "D"), "2000-01-13", None, True, 3),
-        (TDI([1, 7, 11, 20], "D"), "2000-01-13", None, True, 2),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), None, ["lcs_1"], False, 0),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), None, ["lcs_1", "lcs_2"], False, 0),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), "2000-01-10", None, True, 0),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), "2000-01-13", None, True, 0),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), "2000-01-13", None, False, 3),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), "2000-01-13", None, True, 3),
+        (pd.to_timedelta([1, 7, 11, 20], "D"), "2000-01-13", None, True, 2),
         (["2000-01-13", "2000-01-17"], None, None, True, 2),
     ],
 )
@@ -2745,7 +2744,7 @@ def test_coordinate_system_manager_create_coordinate_system():
     rot_mat_x = WXRotation.from_euler("x", angles_x).as_matrix()
     rot_mat_y = WXRotation.from_euler("y", angles_y).as_matrix()
 
-    time = TDI([0, 6, 12, 18], "H")
+    time = pd.to_timedelta([0, 6, 12, 18], "h")
     orientations = np.matmul(rot_mat_x, rot_mat_y)
     coords = Q_([[1, 0, 0], [-1, 0, 2], [3, 5, 7], [-4, -5, -6]], "mm")
 

--- a/weldx/tests/transformations/test_local_cs.py
+++ b/weldx/tests/transformations/test_local_cs.py
@@ -401,7 +401,7 @@ def test_reset_reference_time_exceptions(
     """
     orientation = WXRotation.from_euler("z", [1, 2, 3]).as_matrix()
     coordinates = Q_([[i, i, i] for i in range(3)], "mm")
-    time = TDI([1, 2, 3], "D")
+    time = pd.to_timedelta([1, 2, 3], "D")
 
     lcs = tf.LocalCoordinateSystem(orientation, coordinates, time, time_ref=time_ref)
 
@@ -483,7 +483,7 @@ def test_interp_time_discrete(
     lcs = tf.LocalCoordinateSystem(
         orientation=r_mat_z([0, 0.5, 1, 0.5]),
         coordinates=Q_([[2, 8, 7], [4, 9, 2], [0, 2, 1], [3, 1, 2]], "mm"),
-        time=TDI([10, 14, 18, 22], "D"),
+        time=pd.to_timedelta([10, 14, 18, 22], "D"),
         time_ref=time_ref_lcs,
     )
 
@@ -736,7 +736,7 @@ def test_interp_time_exceptions(
     """
     orientation = r_mat_z([1, 2, 3])
     coordinates = Q_([[i, i, i] for i in range(3)], "mm")
-    time_lcs = TDI([1, 2, 3], "D")
+    time_lcs = pd.to_timedelta([1, 2, 3], "D")
 
     lcs = tf.LocalCoordinateSystem(
         orientation, coordinates, time_lcs, time_ref=time_ref_lcs
@@ -1184,8 +1184,8 @@ def test_comparison_coords_timeseries(
 def test_coordinate_system_init():
     """Check the __init__ method with and without time dependency."""
     # reference data
-    time_0 = TDI([1, 3, 5], "s")
-    time_1 = TDI([2, 4, 6], "s")
+    time_0 = pd.to_timedelta([1, 3, 5], "s")
+    time_1 = pd.to_timedelta([2, 4, 6], "s")
 
     orientation_fix = r_mat_z(1)
     orientation_tdp = r_mat_z([0, 0.25, 0.5])
@@ -1261,7 +1261,7 @@ def test_coordinate_system_init():
         orientation=xr_orientation_tdp_0, coordinates=xr_coordinates_tdp_1
     )
 
-    time_exp = TDI([1, 2, 3, 4, 5, 6], "s")
+    time_exp = pd.to_timedelta([1, 2, 3, 4, 5, 6], "s")
     coordinates_exp = Q_(
         [
             [3, 7, 1],
@@ -1366,7 +1366,7 @@ def test_coordinate_system_factories_time_dependent():
     rot_mat_x = WXRotation.from_euler("x", angles_x).as_matrix()
     rot_mat_y = WXRotation.from_euler("y", angles_y).as_matrix()
 
-    time = TDI([0, 6, 12, 18], "H")
+    time = pd.to_timedelta([0, 6, 12, 18], "h")
     orientations = np.matmul(rot_mat_x, rot_mat_y)
     coords = Q_([[1, 0, 0], [-1, 0, 2], [3, 5, 7], [-4, -5, -6]], "mm")
 
@@ -1408,7 +1408,7 @@ def test_coordinate_system_invert():
     )
 
     # time dependent ----------------------------
-    time = TDI([1, 2, 3, 4], "s")
+    time = pd.to_timedelta([1, 2, 3, 4], "s")
     orientation = r_mat_z([0, 0.5, 1, 0.5])
     coordinates = Q_([[2, 8, 7], [4, 9, 2], [0, 2, 1], [3, 1, 2]], "mm")
 
@@ -1467,7 +1467,7 @@ def coordinate_system_time_interpolation_test_case(
 
 def test_coordinate_system_time_interpolation():
     """Test the local coordinate systems interp_time and interp_like functions."""
-    time_0 = TDI([10, 14, 18, 22], "D")
+    time_0 = pd.to_timedelta([10, 14, 18, 22], "D")
     orientation = r_mat_z([0, 0.5, 1, 0.5])
     coordinates = Q_([[2, 8, 7], [4, 9, 2], [0, 2, 1], [3, 1, 2]], "mm")
 

--- a/weldx/time.py
+++ b/weldx/time.py
@@ -670,7 +670,7 @@ class Time:
             # necessary interfaces so that the function works as expected
             time = np.expand_dims(time, 0)  # type: ignore[assignment]
 
-        delta = pd.TimedeltaIndex(data=time.to(base).magnitude, unit=base)
+        delta = pd.to_timedelta(time.to(base).magnitude, base)
         if time_ref is not None:
             delta = delta + time_ref
         return delta


### PR DESCRIPTION
Pandas 2.2 deprecated the unit argument of the Timedeltaindex constructor and suggests to use pandas.totimedelta function instaed. This PR changes this as suggested.

## Changes

<!--
Describe changes in this PR
-->

## Related Issues

<!--
List related issues and closing issues here
-->

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
