### PR TITLE
replace usages of ``pkg_resources`` with ``importlib.metadata``

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
           init-shell: >-
             bash
             powershell
-          cache-environment: true
+          cache-environment: false
 
       - name: activate build env
         run: micromamba activate rtd

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -77,5 +77,5 @@ required-imports = [
     "from __future__ import annotations",
 ]
 
-[flake8-import-conventions]
+[lint.flake8-import-conventions]
 extend-aliases = { xarray = "xr" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 
 - rename (fix typo) argument to `lcs_child_in_parent` in `CoordinateSystemManager.add_cs`  \[{pull}`936`\].
 
-- replace usages of ``pkg_resources`` with ``importlib.metadata`` [#941]
+- replace usages of `pkg_resources` with `importlib.metadata` \[{pull}`941`\].
 
 ### Dependencies
 
 - pin `weldx-widgets>=0.2.3` for viz \[{pull}`939`\].
+- pin `pint>=0.21` \[{pull}`941`\].
 
 ## 0.6.8 (07.06.2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - rename (fix typo) argument to `lcs_child_in_parent` in `CoordinateSystemManager.add_cs`  \[{pull}`936`\].
 
+- replace usages of ``pkg_resources`` with ``importlib.metadata`` [#941]
+
 ### Dependencies
 
 - pin `weldx-widgets>=0.2.3` for viz \[{pull}`939`\].

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -32,5 +32,5 @@ dependencies:
   # pip packages
   - pip
   - pip:
-    - ../
-    - ./json_mime_render_plugin/
+    - weldx @ file:/../..//
+    - json_mime_render_plugin @ file:/..//json_mime_render_plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,16 @@ dependencies = [
   "sympy>=1.6",
   "xarray>=2022.9",
 ]
+optional-dependencies.docs = [
+  "docutils>=0.19",
+  "numpydoc>=0.5",
+  "pydata-sphinx-theme<0.15",             # parallel-write-unsafe
+  "sphinx>=4.1.1,==7.2",
+  "sphinx-autodoc-typehints>=1.21.8,==2",
+  "sphinx-copybutton==0.5",
+  "typing-extensions",
+  "urllib3<2",
+]
 optional-dependencies.media = [
   "av",
   "dask-image",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "networkx>=2.8.2",
   "numpy>=1.20,<2",
   "pandas>=1.5",
-  "pint>=0.18",
+  "pint>=0.21",
   "pint-xarray>=0.3",
   "psutil",
   "scipy>=1.6.2",

--- a/weldx/config.py
+++ b/weldx/config.py
@@ -177,7 +177,7 @@ class Config:
     def load_installed_standards():
         """Load all standards that are installed to the active virtual environment."""
         if sys.version_info < (3, 10):
-            entry_points = importlib.metadata.entry_points()["weldx.standard"]
+            entry_points = importlib.metadata.entry_points().get("weldx.standard", [])
         else:
             entry_points = importlib.metadata.entry_points().select(
                 group="weldx.standard"

--- a/weldx/config.py
+++ b/weldx/config.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 from pathlib import Path
 
 import asdf
-import importlib.metadata
 import yaml
 from asdf.config import ResourceMappingProxy
 from asdf.versioning import AsdfVersion, split_tag_version

--- a/weldx/config.py
+++ b/weldx/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import sys
 from pathlib import Path
 
 import asdf
@@ -175,9 +176,13 @@ class Config:
     @staticmethod
     def load_installed_standards():
         """Load all standards that are installed to the active virtual environment."""
-        for entry_point in importlib.metadata.entry_points().select(
-            group="weldx.standard"
-        ):
+        if sys.version_info < (3, 10):
+            entry_points = importlib.metadata.entry_points()["weldx.standard"]
+        else:
+            entry_points = importlib.metadata.entry_points().select(
+                group="weldx.standard"
+            )
+        for entry_point in entry_points:
             standards = entry_point.load()()
             if not isinstance(standards, list):
                 standards = [standards]

--- a/weldx/config.py
+++ b/weldx/config.py
@@ -175,7 +175,9 @@ class Config:
     @staticmethod
     def load_installed_standards():
         """Load all standards that are installed to the active virtual environment."""
-        for entry_point in importlib.metadata.entry_points()["weldx.standard"]:
+        for entry_point in importlib.metadata.entry_points().select(
+            group="weldx.standard"
+        ):
             standards = entry_point.load()()
             if not isinstance(standards, list):
                 standards = [standards]

--- a/weldx/config.py
+++ b/weldx/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import asdf
-import pkg_resources
+import importlib.metadata
 import yaml
 from asdf.config import ResourceMappingProxy
 from asdf.versioning import AsdfVersion, split_tag_version
@@ -175,7 +175,7 @@ class Config:
     @staticmethod
     def load_installed_standards():
         """Load all standards that are installed to the active virtual environment."""
-        for entry_point in pkg_resources.iter_entry_points("weldx.standard"):
+        for entry_point in importlib.metadata.entry_points()["weldx.standard"]:
             standards = entry_point.load()()
             if not isinstance(standards, list):
                 standards = [standards]

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -16,7 +16,6 @@ WELDX_PATH = _Path(__file__).parent.resolve()
 
 WELDX_UNIT_REGISTRY = pint.UnitRegistry(
     preprocessors=[
-        lambda string: string.replace("%", "percent"),  # allow %-sign
         lambda string: string.replace("Δ°", "delta_deg"),  # parse Δ° for temperature
     ],
     force_ndarray_like=True,

--- a/weldx/tests/_helpers.py
+++ b/weldx/tests/_helpers.py
@@ -1,10 +1,10 @@
 """Provides some utility functions for tests."""
 
+import importlib.metadata
 from typing import Any
 
 import numpy as np
 import pint
-import importlib.metadata
 
 from weldx.constants import Q_
 from weldx.geometry import _vector_is_close as vector_is_close
@@ -130,7 +130,9 @@ def matrix_is_close(mat_a, mat_b, abs_tol=1e-9) -> bool:
         return False
 
     atol_unit = 1.0
-    if isinstance(mat_b, pint.Quantity) and tuple(int(part) for part in importlib.metadata.version("pint").split(".")) >= (0, 21):
+    if isinstance(mat_b, pint.Quantity) and tuple(
+        int(part) for part in importlib.metadata.version("pint").split(".")
+    ) >= (0, 21):
         atol_unit = mat_b.u
 
     return np.all(np.isclose(mat_a, mat_b, atol=abs_tol * atol_unit)).__bool__()

--- a/weldx/tests/_helpers.py
+++ b/weldx/tests/_helpers.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 import pint
-from pkg_resources import get_distribution
+import importlib.metadata
 
 from weldx.constants import Q_
 from weldx.geometry import _vector_is_close as vector_is_close
@@ -130,7 +130,7 @@ def matrix_is_close(mat_a, mat_b, abs_tol=1e-9) -> bool:
         return False
 
     atol_unit = 1.0
-    if isinstance(mat_b, pint.Quantity) and get_distribution("pint").version >= "0.21":
+    if isinstance(mat_b, pint.Quantity) and tuple(int(part) for part in importlib.metadata.version("pint").split(".")) >= (0, 21):
         atol_unit = mat_b.u
 
     return np.all(np.isclose(mat_a, mat_b, atol=abs_tol * atol_unit)).__bool__()

--- a/weldx/tests/_helpers.py
+++ b/weldx/tests/_helpers.py
@@ -1,6 +1,5 @@
 """Provides some utility functions for tests."""
 
-import importlib.metadata
 from typing import Any
 
 import numpy as np
@@ -130,9 +129,7 @@ def matrix_is_close(mat_a, mat_b, abs_tol=1e-9) -> bool:
         return False
 
     atol_unit = 1.0
-    if isinstance(mat_b, pint.Quantity) and tuple(
-        int(part) for part in importlib.metadata.version("pint").split(".")
-    ) >= (0, 21):
+    if isinstance(mat_b, pint.Quantity):
         atol_unit = mat_b.u
 
     return np.all(np.isclose(mat_a, mat_b, atol=abs_tol * atol_unit)).__bool__()

--- a/weldx/tests/transformations/_util.py
+++ b/weldx/tests/transformations/_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-from pkg_resources import get_distribution
+import importlib.metadata
 from xarray import DataArray
 
 import weldx.transformations as tf
@@ -79,7 +79,7 @@ def check_coordinate_system(
     )
 
     atol_unit = 1.0
-    if get_distribution("pint").version >= "0.21":
+    if tuple(int(part) for part in importlib.metadata.version("pint").split(".")) >= (0, 21):
         atol_unit = coordinates_expected.u
 
     assert np.allclose(

--- a/weldx/tests/transformations/_util.py
+++ b/weldx/tests/transformations/_util.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-import importlib.metadata
 from xarray import DataArray
 
 import weldx.transformations as tf
@@ -78,9 +77,7 @@ def check_coordinate_system(
         lcs.orientation, orientation_expected, positive_orientation_expected
     )
 
-    atol_unit = 1.0
-    if tuple(int(part) for part in importlib.metadata.version("pint").split(".")) >= (0, 21):
-        atol_unit = coordinates_expected.u
+    atol_unit = coordinates_expected.u
 
     assert np.allclose(
         lcs.coordinates.data, coordinates_expected, atol=1e-9 * atol_unit


### PR DESCRIPTION
## Changes

<!--
Describe changes in this PR
-->

attempting to fix issues in readthedocs build:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/weldx/checkouts/940/doc/src/conf.py", line 65, in <module>
    import weldx
  File "/home/docs/checkouts/readthedocs.org/user_builds/weldx/conda/940/lib/python3.10/site-packages/weldx/__init__.py", line 144, in <module>
    import weldx.config
  File "/home/docs/checkouts/readthedocs.org/user_builds/weldx/conda/940/lib/python3.10/site-packages/weldx/config.py", line 8, in <module>
    import pkg_resources
  File "/home/docs/checkouts/readthedocs.org/user_builds/weldx/conda/940/lib/python3.10/site-packages/pkg_resources/__init__.py", line 105, in <module>
    from _typeshed import BytesPath, StrPath, StrOrBytesPath
ModuleNotFoundError: No module named '_typeshed'
```
https://readthedocs.org/projects/weldx/builds/25043814/

## Related Issues

<!--
List related issues and closing issues here
-->

## Checks

- [x] updated `CHANGELOG.md`
- [x] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
