### PR TITLE
add upper pin for asdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - pin `weldx-widgets>=0.2.3` for viz \[{pull}`939`\].
 - pin `pint>=0.21` \[{pull}`941`\].
 - pin `python<3.13` \[{pull}`896`\].
+- pin `asdf<4` \[{pull}`952`\].
 
 ## 0.6.8 (07.06.2024)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = [
   "version", # version gets derived from git by setuptools_scm.
 ]
 dependencies = [
-  "asdf>=2.15.1",
+  "asdf>=2.15.1,<4",
   "bidict",
   "boltons",
   "bottleneck>=1.3.3",


### PR DESCRIPTION
## Changes

asdf is preparing to make a 4.0.0 release. It contains a few breaking changes that will impact weldx. The major ones are:
- removal of deprecated imports (like `asdf.asdf`)
- switching to ASDF standard 1.6.0 as the default version when writing files

See https://github.com/BAMWelDX/weldx/pull/910 for changes that should make weldx 4.x compatible.

This PR is an alternative which pins asdf to "<4".

## Related Issues

<!--
List related issues and closing issues here
-->

## Checks

- [x] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
