### PR TITLE
unpin numpy, python

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        py: ['3.9', '3.10', '3.11', '3.12']
+        py: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -52,8 +52,8 @@ jobs:
           files: 'pyproject.toml'
           channels: 'conda-forge defaults'
           extras: 'test vis media'
-          additional_requirements: weldx-widgets
-          pip: weldx-widgets weldx@file:/..//
+          additional_requirements: 'weldx-widgets weldx@file:/..//'
+          pip: 'weldx-widgets'
           build_system: 'include'
 
       - name: Setup Conda Environment

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,11 +34,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         py: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        asdf: ['4']
+        asdf: ['3']
         include:
           - os: ubuntu-latest
             py: '3.10'
-            asdf: 3
+            asdf: 4
           - os: ubuntu-latest
             py: '3.10'
             asdf: 2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: '0' # Fetch all history for all tags and branches
 
-      - uses: CagtayFabry/pydeps2env@vmain
+      - uses: CagtayFabry/pydeps2env@main
         with:
           files: 'pyproject.toml'
           channels: 'conda-forge defaults'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,11 +47,13 @@ jobs:
         with:
           fetch-depth: '0' # Fetch all history for all tags and branches
 
-      - uses: CagtayFabry/pydeps2env@v1.3.0
+      - uses: CagtayFabry/pydeps2env@vmain
         with:
           files: 'pyproject.toml'
           channels: 'conda-forge defaults'
           extras: 'test vis media'
+          additional_requirements: weldx-widgets
+          pip: weldx-widgets weldx@file:/..//
           build_system: 'include'
 
       - name: Setup Conda Environment

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,11 +34,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         py: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        asdf: ['3']
+        asdf: ['4']
         include:
           - os: ubuntu-latest
             py: '3.10'
-            asdf: 4
+            asdf: 3
           - os: ubuntu-latest
             py: '3.10'
             asdf: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Dependencies
 
 - remove upper pin for `asdf` \[{pull}`910`\].
+- remove upper pin for `numpy` \[{pull}`959`\].
+- pin `python<3.14` \[{pull}`959`\].
+- pin `weldx-widgets>=0.2.5` for viz \[{pull}`959`\].
 
 ### ASDF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Dependencies
 
 - remove upper pin for `asdf` \[{pull}`910`\].
+- pin `asdf<5` \[{pull}`959`\].
 - remove upper pin for `numpy` \[{pull}`959`\].
 - pin `python<3.14` \[{pull}`959`\].
 - pin `weldx-widgets>=0.2.5` for viz \[{pull}`959`\].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dynamic = [
   "version", # version gets derived from git by setuptools_scm.
 ]
 dependencies = [
-  "asdf>=2.15.1",
+  "asdf>=2.15.1,<5",
   "bidict",
   "boltons",
   "bottleneck>=1.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
   { name = "Martin K. Scherer", email = "martin.scherer@bam.de" },
   { name = "Michael Winkler", email = "michael.winkler@bam.de" },
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Education",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Physics",  # TODO: add more topics here!
 ]
 dynamic = [
@@ -51,7 +52,7 @@ dependencies = [
   "ipython",
   "meshio",
   "networkx>=2.8.2",
-  "numpy>=1.20,<2",
+  "numpy>=1.20",
   "pandas>=1.5",
   "pint>=0.21",
   "pint-xarray>=0.3",
@@ -83,7 +84,7 @@ optional-dependencies.test = [
   "pytest-xdist",
 ]
 optional-dependencies.vis = [
-  "weldx-widgets>=0.2.3",
+  "weldx-widgets>=0.2.5",
 ]
 urls.bug_tracker = "https://github.com/BAMweldx/weldx/issues"
 urls.changelog = "https://github.com/BAMweldx/weldx/blob/master/CHANGELOG.md"

--- a/weldx/tests/asdf_tests/test_weldx_file.py
+++ b/weldx/tests/asdf_tests/test_weldx_file.py
@@ -635,7 +635,7 @@ properties:
             tree=dict(x=x), mode="rw", array_inline_threshold=len(x) + 1
         ).file_handle
         buff.seek(0)
-        assert str(list(x)).encode("utf-8") in buff.read()
+        assert str([int(v) for v in x]).encode("utf-8") in buff.read()
 
         # now we create an array longer than the default threshold
         y = np.arange(DEFAULT_ARRAY_INLINE_THRESHOLD + 3)
@@ -643,7 +643,7 @@ properties:
         buff2.seek(0)
         data = buff2.read()
         assert b"BLOCK" in data
-        assert str(list(y)).encode("utf-8") not in data
+        assert str([int(v) for v in x]).encode("utf-8") not in data
 
     @staticmethod
     def test_array_inline_threshold_sync():

--- a/weldx/tests/test_utility.py
+++ b/weldx/tests/test_utility.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from numpy import NaN
 from pint.errors import DimensionalityError
 from xarray import DataArray
 
@@ -18,6 +17,10 @@ from weldx.constants import META_ATTR, Q_, U_, UNITS_KEY
 from weldx.exceptions import WeldxDeprecationWarning
 from weldx.time import Time
 
+if np.__version__ >= "2.0.0":
+    from numpy import nan as NaN
+else:
+    from numpy import NaN
 
 def test_deprecation_decorator():
     """Test that the deprecation decorator emits a warning as expected."""

--- a/weldx/tests/test_utility.py
+++ b/weldx/tests/test_utility.py
@@ -22,6 +22,7 @@ if np.__version__ >= "2.0.0":
 else:
     from numpy import NaN
 
+
 def test_deprecation_decorator():
     """Test that the deprecation decorator emits a warning as expected."""
 


### PR DESCRIPTION
## Changes

- remove upper pin for `numpy`
- pin `python<3.14`
- pin `weldx-widgets>=0.2.5`

- minor numpy>=2 compatibility fixes

## Related Issues

<!--
List related issues and closing issues here
-->

## Checks

- [x] updated `CHANGELOG.md`
- [x] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
