### PR TITLE
pin pint_xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
   "numpy>=1.20",
   "pandas>=1.5",
   "pint>=0.21",
-  "pint-xarray>=0.3",
+  "pint-xarray>=0.5",
   "psutil",
   "scipy>=1.6.2",
   "sympy>=1.6",


### PR DESCRIPTION
TEST pr to try and sort out asdf downstream failures.

It looks like there is a pint-xarray 0.5.0:
https://github.com/xarray-contrib/pint-xarray/releases/tag/v0.5.0
which is being picked up in the asdf downstream tests:
https://github.com/asdf-format/asdf/actions/runs/15529002196/job/43908543462#step:10:384
(possibly because those are using pypi)
but not picked up here:
https://github.com/BAMWelDX/weldx/actions/runs/15591385291/job/43911096820?pr=989#step:5:29
Maybe this is a conda vs pypi issue but it does appear that conda-forge does have a 0.5.0:
https://anaconda.org/conda-forge/pint-xarray

I don't know what was preventing it but now that 0.5.0 is picked up (by forcing the lower pin) the failures are appearing here.