### PR TITLE
pin pint-xarray<0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.2 (unreleased)
+
+### Dependencies
+
+- pin `pint-xarray<0.5` due to incopatibility in handling of units with xarray coordinates \[{pull}`991`\]
+
 ## 0.7.1 (23.04.2025)
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
   "numpy>=1.20",
   "pandas>=1.5",
   "pint>=0.21",
-  "pint-xarray>=0.3",
+  "pint-xarray>=0.3,<0.5",
   "psutil",
   "scipy>=1.6.2",
   "sympy>=1.6",


### PR DESCRIPTION
## Changes

- pin `pint-xarray<0.5`

## Related Issues

see https://github.com/BAMWelDX/weldx/issues/990

## Checks

- [x] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
