### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.3 (unreleased)
+
+### Dependencies
+
+- add `pytest-asdf-plugin` to `test` dependency for schema tests \[{pull}`997`\]
+
 ## 0.7.2 (10.07.2025)
 
 ### Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ optional-dependencies.media = [
 optional-dependencies.test = [
   "nbval",
   "pytest>=6",
+  "pytest-asdf-plugin",
   "pytest-cov",
   "pytest-xdist",
 ]


### PR DESCRIPTION
## Changes

Update test dependencies to use new https://pypi.org/project/pytest-asdf-plugin/ which is a feature-compatible replacement for the bundled asdf pytest plugin (which will soon be deprecated).

For context the pytest-asdf-plugin is responsible for finding and converting schema files into "tests" (to check the schema against the metaschema and validated any contained "examples"). Since both the bundled and now external plugins are feature-compatible there should be no change in test number (or new failures, etc).

On main 153 tests passed:
https://github.com/BAMWelDX/weldx/actions/runs/17033022164/job/48279380582#step:7:130

With this PR 153 tests passed:
https://github.com/BAMWelDX/weldx/actions/runs/17050088327/job/48335364972?pr=997#step:7:130

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
