### PR TITLE
Remove deprecated usage of `np.cross` with 2d vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.4 (unreleased)
+
+### Fixes
+
+- remove usage of deprecated `np.cross` with 2-d vectors \[{pull}`1028`\]
+
 ## 0.7.3 (02.03.2026)
 
 ### Dependencies

--- a/weldx/geometry.py
+++ b/weldx/geometry.py
@@ -626,8 +626,9 @@ class ArcSegment(DynamicShapeSegment):
         self._radius = Q_(np.linalg.norm(diff.m), self._points.u)
 
         expr = "(x*cos(a+s*w)+y*sin(a+s*w))*r + o"
-        sign = -1 if np.cross([1, 0], diff.m) < 0 else 1
-        a = np.arccos(np.dot([1, 0], diff.m) / self._radius.m) * sign
+
+        a = np.arccos(np.dot([1, 0], diff.m) / self._radius.m)
+        a = np.copysign(a, diff.m[..., 1])
 
         params = dict(
             x=Q_([1, 0, 0], ""),


### PR DESCRIPTION
## Changes

* Removed usage of `np.cross` with 2d vectors which was deprecated in Numpy 2.0 and became unsupported in Numpy 2.5.0

## Related Issues

Closes #1029 

## Checks

- [ ] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
