### PR TITLE
Missing Dependencies added and other fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,18 +46,31 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
+      - uses: CagtayFabry/pydeps2env@v1.4.1
+        with:
+          file: 'pyproject.toml'
+          channels: 'conda-forge'
+          extras: 'docs vis'
+          setup_requires: 'include'
+
       - name: Setup Conda Environment
         uses: mamba-org/setup-micromamba@v2.0.7
         with:
-          environment-file: ./doc/rtd_environment.yml
-          environment-name: rtd
+          environment-file: ./environment.yml
+          environment-name: weldx
           init-shell: >-
             bash
             powershell
           cache-environment: false
+          create-args: >-
+            python=3.12
 
       - name: activate build env
-        run: micromamba activate rtd
+        run: micromamba activate weldx
+
+      - name: pip installs
+        run: |
+          python -m pip install -e .
 
       - name: conda info
         run: conda info

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "mambaforge-4.10"
+    python: "3.12"
   jobs:
     post_checkout:
       - git fetch --unshallow
@@ -28,8 +28,14 @@ sphinx:
 ##formats:
 ##  - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
-#build:
-#  image: testing
-conda:
-  environment: doc/rtd_environment.yml
+# Install weldx with the docs+vis extras directly via pip instead of a separate conda
+# environment file, so pyproject.toml stays the single source of truth for versions.
+# `vis` (weldx-widgets) is required too: the tutorial notebooks executed during the
+# build call plotting functions that need the real implementation, not its fallback stub.
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - vis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,49 @@
 
 ## 0.7.4 (unreleased)
 
+### Dependencies
+
+- keep the minimum supported Python version at 3.9; 3.12 is the primary target,
+  3.9/3.10/3.11/3.13 are spot-checked
+- add `pyyaml`, `packaging`, `decorator` as declared runtime dependencies -- they were already
+  hard requirements (used by `weldx.config`, `weldx.asdf.util`, `weldx.util.util` respectively)
+  but only worked by accident via transitive installs
+- `media` extra: add missing `pillow` dependency
+- `docs` extra: add missing `ipywidgets` dependency
+- add a new `plot` extra (`matplotlib`, `k3d`) to make explicit the previously-undeclared,
+  lazily-imported soft dependencies used by `weldx.geometry`, `weldx.measurement`,
+  `weldx.core.time_series` and `weldx.transformations`
+- remove the `asdf<5` upper pin (tested clean against asdf 5.3.1)
+- `vis` extra: raise the `weldx-widgets` floor to `>=0.3.3`, which fixes compatibility with
+  matplotlib>=3.9 upstream; this replaces the transitional `matplotlib<3.9` pin this extra
+  would otherwise need
+- bump `sphinx-copybutton` to `0.5.2`; unpin `urllib3`
+- re-verified and kept: `pandas<3` (breaks `weldx.time.Time` list/DatetimeIndex conversion),
+  `scipy<1.17` (breaks `WXRotation.from_euler` for single-axis sequences), `pint-xarray<0.5`
+  (raises on xarray coordinate unit conversion), `setuptools<82` (drops `pkg_resources`, which
+  `fs` needs), `sphinx==7.2` / `pydata-sphinx-theme<0.15` / `sphinx-autodoc-typehints==2` (the
+  latest releases of `myst-parser`, `pydata-sphinx-theme` and `sphinx-autodoc-typehints`
+  require mutually exclusive Sphinx version ranges -- no combination of current releases
+  works together, so this needs a coordinated follow-up, not attempted here)
+
 ### Fixes
 
 - remove usage of deprecated `np.cross` with 2-d vectors \[{pull}`1028`\]
+- replace the abandoned `attrdict` dependency in `weldx.util.media_file.MediaFile.attrs` with a
+  small local dict subclass -- `attrdict` cannot be imported on Python>=3.10
+- fix the Sphinx doc build against current dependency versions: a `packaging`-internal circular
+  import newly triggered by the `TYPE_CHECKING=True` build hack in `doc/src/conf.py`, the same
+  hack breaking on scipy's and matplotlib's own `TYPE_CHECKING`-only imports, a numpy-version
+  intersphinx URL that broke for numpy>=2's `X.Y.Z` format, and scipy's docs no longer serving
+  per-version intersphinx inventories
+
+### CI
+
+- `.readthedocs.yml` now installs via `pip install .[docs,vis]` instead of a separate,
+  independently-drifting conda environment file; `doc/rtd_environment.yml` is removed
+- `.github/workflows/docs.yml` now generates its conda environment from `pyproject.toml` via
+  `pydeps2env`, matching the pattern already used by the other CI workflows
+- trim `devtools/environment.yml` to match current tooling and dependencies
 
 ## 0.7.3 (02.03.2026)
 

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -1,20 +1,23 @@
 name: weldx
 channels:
-  - defaults
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.12
   - setuptools_scm
-  - numpy>=1.18
-  - pandas>=1.0
-  - scipy<1.6
+  - numpy>=1.20
+  - pandas>=1.5,<3
+  - scipy>=1.6.2,<1.17
   - sympy>=1.6
-  - xarray>=0.15
-  - pint>=0.11
-  - bottleneck
+  - xarray>=2022.9
+  - pint>=0.21
+  - pint-xarray>=0.3,<0.5
+  - bottleneck>=1.3.3
   - boltons
-  - asdf>=2.8
-  - openpyxl
+  - bidict
+  - decorator
+  - packaging
+  - pyyaml
+  - asdf>=2.15.1
   - fs
   - meshio
   # graph packages
@@ -26,27 +29,31 @@ dependencies:
   - pytest-xdist
   - nbval
   - ruff
-  - black
   - nbqa
-  # Plotting
+  # Plotting (weldx.plot extra)
   - ipykernel
   - ipympl
   - k3d
-  - line_profiler
   - matplotlib
+  - line_profiler
   - memory_profiler
   - seaborn
   - snakeviz
+  # media extra
+  - av
+  - dask-image
+  - pillow
+  - tifffile
   # documentation
-  - sphinx
-  - recommonmark
-  - sphinxcontrib-napoleon
-  - nbsphinx
-  - sphinx-copybutton
-  - pydata-sphinx-theme
+  - sphinx>=4.1.1,==7.2
+  - sphinx-copybutton==0.5
+  - pydata-sphinx-theme<0.15
   - numpydoc>=0.5
-  - sphinx-autodoc-typehints
+  - sphinx-autodoc-typehints>=1.21.8,==2
+  - ipywidgets
+  - myst-parser
+  - urllib3<2
   # pip packages
   - pip
   - pip:
-    - git+https://github.com/CagtayFabry/sphinx-asdf.git@sphinx-weldx
+    - myst-nb-json

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -34,9 +34,11 @@ def _workaround_imports_typechecking():
     """
 
     import ipywidgets  # noqa
+    import matplotlib.axes  # noqa
     import meshio  # noqa
     import pandas  # noqa
     import pint  # noqa
+    import scipy.spatial.transform  # noqa
     import sympy  # noqa
     import xarray  # noqa
 
@@ -50,6 +52,7 @@ def _prevent_sphinx_circular_imports_bug():
     import myst_nb.ext.eval  # noqa
     import myst_parser  # noqa
     import myst_parser.mdit_to_docutils.base  # noqa
+    import packaging.specifiers  # noqa
     import sphinx.builders.html  # noqa
     import sphinx.builders.latex  # noqa
     import sphinx.builders.texinfo  # noqa
@@ -68,6 +71,9 @@ except ModuleNotFoundError:  # fallback for local use
     import weldx
 
 import weldx.visualization  # load visualization (currently no auto-import in pkg).
+
+typing.TYPE_CHECKING = False  # restore, so later imports (e.g. Sphinx extensions
+# like linkcheck, which conditionally import typeshed-only stubs) aren't affected.
 
 # -- Project information -----------------------------------------------------
 project = "weldx"
@@ -250,18 +256,22 @@ def _get_intersphinx_mapping():
     from numpy import __version__ as numpy_version
     from pandas import __version__ as pandas_version
     from pint import __version__ as pint_version
-    from scipy import __version__ as scipy_version
 
     intersphinx_mapping_ = {
         "python": ("https://docs.python.org/3/", None),
-        "numpy": (f"https://numpy.org/doc/{numpy_version[:4]}", None),
+        "numpy": (
+            f"https://numpy.org/doc/{'.'.join(numpy_version.split('.')[:2])}",
+            None,
+        ),
         "pandas": (
             f"https://pandas.pydata.org/pandas-docs/version/{pandas_version}/",
             None,
         ),
         # "xarray": (f"https://docs.xarray.dev/en/v{xarray_version}", None),
         "xarray": ("https://docs.xarray.dev/en/v2022.06.0/", None),
-        "scipy": (f"https://docs.scipy.org/doc/scipy-{scipy_version}/", None),
+        # docs.scipy.org no longer publishes per-version inventories (404s), only
+        # an unversioned "latest" one.
+        "scipy": ("https://docs.scipy.org/doc/scipy/", None),
         "matplotlib": (f"https://matplotlib.org/{matplotlib_version}", None),
         # "dask": ("https://docs.dask.org/en/latest", None),
         # "numba": ("https://numba.pydata.org/numba-doc/latest", None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,40 +43,66 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "asdf>=2.15.1,<5",
+  "asdf>=2.15.1",
   "bidict",
   "boltons",
   "bottleneck>=1.3.3",
+  "decorator",              # used by weldx.util.util
   "fs",
   "ipython>=8",
   "meshio",
   "networkx>=2.8.2",
   "numpy>=1.20",
-  "pandas>=1.5,<3",
+  "packaging",              # used by weldx.asdf.util
+  "pandas>=1.5,<3",         # pandas>=3 breaks weldx.time.Time list/DatetimeIndex conversion
   "pint>=0.21",
-  "pint-xarray>=0.3,<0.5",
+  "pint-xarray>=0.3,<0.5",  # pint-xarray>=0.5 raises ValueError("cannot convert
+                            # non-quantified index") in weldx.util.xarray.xr_interp_like
   "psutil",
-  "scipy>=1.6.2,<1.17",
-  "setuptools<82",
+  "pyyaml",                 # used by weldx.config
+  "scipy>=1.6.2,<1.17",     # scipy>=1.17 tightened Rotation.from_euler validation for
+                            # single-axis sequences (e.g. seq="x"), breaking WXRotation
+                            # call sites throughout weldx.transformations and its tests
+  "setuptools<82",          # setuptools>=82 dropped pkg_resources, which `fs` needs for
+                            # its namespace-package declaration at import time
   "sympy>=1.6",
   "xarray>=2022.9",
 ]
 optional-dependencies.docs = [
   "docutils>=0.19",
+  "ipywidgets",
   "myst-nb-json",
   "numpydoc>=0.5",
-  "pydata-sphinx-theme<0.15",             # parallel-write-unsafe
-  "sphinx>=4.1.1,==7.2",
-  "sphinx-autodoc-typehints>=1.21.8,==2",
-  "sphinx-copybutton==0.5",
+  "pydata-sphinx-theme<0.15",             # parallel-write-unsafe; also pydata-sphinx-theme
+                                           # >=0.20 requires sphinx>=8.2, which conflicts
+                                           # with sphinx-autodoc-typehints (see below)
+  "sphinx>=4.1.1,==7.2",                  # myst-parser (pulled in via myst-nb) caps at
+                                           # sphinx<9; sphinx-autodoc-typehints>=3 requires
+                                           # sphinx>=9.1 -- no version satisfies both, so the
+                                           # whole toolchain (sphinx/myst-parser/
+                                           # pydata-sphinx-theme/sphinx-autodoc-typehints)
+                                           # needs a coordinated bump, not attempted here
+  "sphinx-autodoc-typehints>=1.21.8,==2", # see sphinx comment above
+  "sphinx-copybutton==0.5.2",
   "typing-extensions",
-  "urllib3<2",
+  "urllib3",
 ]
 optional-dependencies.media = [
   "av",
   "dask-image",
+  "pillow",
   "pims",
   "tifffile",   # required by dask-image, but not listed in their requirements
+]
+# matplotlib and k3d are optional, soft dependencies used directly by core modules
+# (weldx.geometry, weldx.measurement, weldx.core.time_series,
+# weldx.transformations.cs_manager/local_cs). They are always imported lazily and
+# guarded by check_matplotlib_available/k3d-availability checks, which warn instead
+# of raising if the plotting backend is missing -- install this extra to silence
+# those warnings and get plotting support.
+optional-dependencies.plot = [
+  "k3d",
+  "matplotlib",
 ]
 optional-dependencies.test = [
   "nbval",
@@ -86,7 +112,10 @@ optional-dependencies.test = [
   "pytest-xdist",
 ]
 optional-dependencies.vis = [
-  "weldx-widgets>=0.2.5",
+  # weldx-widgets>=0.3.3 replaces the removed plt.cm.get_cmap() call, allowing
+  # matplotlib to stay unpinned here (see BAMWelDX/weldx-widgets fix, released
+  # after v0.3.2).
+  "weldx-widgets>=0.3.3",
 ]
 urls.bug_tracker = "https://github.com/BAMweldx/weldx/issues"
 urls.changelog = "https://github.com/BAMweldx/weldx/blob/master/CHANGELOG.md"
@@ -110,7 +139,10 @@ addopts.ruff = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+# numpy's bundled .pyi stubs use PEP 695 `type` statements, which mypy refuses to parse
+# below python_version 3.12 -- set to 3.12 (also the project's primary target) rather
+# than the 3.9 floor, which is instead enforced via requires-python and CI's test matrix.
+python_version = "3.12"
 files = "weldx"
 ignore_missing_imports = true  # TODO: this is bad!
 strict_optional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,19 +47,19 @@ dependencies = [
   "bidict",
   "boltons",
   "bottleneck>=1.3.3",
-  "decorator",              # used by weldx.util.util
+  "decorator",
   "fs",
   "ipython>=8",
   "meshio",
   "networkx>=2.8.2",
   "numpy>=1.20",
-  "packaging",              # used by weldx.asdf.util
+  "packaging",
   "pandas>=1.5,<3",         # pandas>=3 breaks weldx.time.Time list/DatetimeIndex conversion
   "pint>=0.21",
   "pint-xarray>=0.3,<0.5",  # pint-xarray>=0.5 raises ValueError("cannot convert
                             # non-quantified index") in weldx.util.xarray.xr_interp_like
   "psutil",
-  "pyyaml",                 # used by weldx.config
+  "pyyaml",
   "scipy>=1.6.2,<1.17",     # scipy>=1.17 tightened Rotation.from_euler validation for
                             # single-axis sequences (e.g. seq="x"), breaking WXRotation
                             # call sites throughout weldx.transformations and its tests
@@ -94,12 +94,6 @@ optional-dependencies.media = [
   "pims",
   "tifffile",   # required by dask-image, but not listed in their requirements
 ]
-# matplotlib and k3d are optional, soft dependencies used directly by core modules
-# (weldx.geometry, weldx.measurement, weldx.core.time_series,
-# weldx.transformations.cs_manager/local_cs). They are always imported lazily and
-# guarded by check_matplotlib_available/k3d-availability checks, which warn instead
-# of raising if the plotting backend is missing -- install this extra to silence
-# those warnings and get plotting support.
 optional-dependencies.plot = [
   "k3d",
   "matplotlib",
@@ -139,9 +133,6 @@ addopts.ruff = [
 ]
 
 [tool.mypy]
-# numpy's bundled .pyi stubs use PEP 695 `type` statements, which mypy refuses to parse
-# below python_version 3.12 -- set to 3.12 (also the project's primary target) rather
-# than the 3.9 floor, which is instead enforced via requires-python and CI's test matrix.
 python_version = "3.12"
 files = "weldx"
 ignore_missing_imports = true  # TODO: this is bad!

--- a/weldx/constants.py
+++ b/weldx/constants.py
@@ -14,7 +14,7 @@ UNITS_KEY = "units"
 
 WELDX_PATH = _Path(__file__).parent.resolve()
 
-WELDX_UNIT_REGISTRY = pint.UnitRegistry(
+WELDX_UNIT_REGISTRY: pint.UnitRegistry = pint.UnitRegistry(
     preprocessors=[
         lambda string: string.replace("Δ°", "delta_deg"),  # parse Δ° for temperature
     ],

--- a/weldx/util/media_file.py
+++ b/weldx/util/media_file.py
@@ -34,6 +34,16 @@ types_media_input = Union[
 _AV_TIME_BASE = 1000000
 
 
+class _AttrDict(dict):
+    """Dict whose keys are also accessible as attributes (replaces pkg attrdict)."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+
 def _pts_to_frame(pts, time_base, frame_rate, start_time):
     return int(pts * time_base * frame_rate) - int(start_time * time_base * frame_rate)
 
@@ -196,9 +206,7 @@ class MediaFile:
     @property
     def attrs(self):
         """Video attributes."""
-        from attrdict import AttrDict
-
-        return AttrDict(self._metadata)
+        return _AttrDict(self._metadata)
 
     @property
     def resolution(self) -> tuple[int, int]:

--- a/weldx/util/xarray.py
+++ b/weldx/util/xarray.py
@@ -340,7 +340,7 @@ def xr_interp_like(
 
     # create a new (empty) temporary dataset to use for interpolation
     # we need this if da2 is passed as an existing coordinate variable like origin.time
-    da_temp_coords = _coordinates_from_quantities(sel_coords)
+    da_temp_coords = _coordinates_from_quantities(sel_coords)  # type: ignore[arg-type]
     da_temp = xr.DataArray(dims=sel_coords.keys(), coords=da_temp_coords)
 
     # convert base array units to indexer units
@@ -607,7 +607,7 @@ def xr_3d_vector(
     coords = dict(c=["x", "y", "z"])
 
     # if data is static but time passed we discard time information
-    if time is not None and Q_(data).ndim == 1:
+    if time is not None and Q_(data).ndim == 1:  # type: ignore[type-var]
         time = None
 
     # remove duplicates and keep order


### PR DESCRIPTION
## Changes
Summary:
- Added missing dependencies (among others "decorator" fixes #1033)
- Validated current dependency constraints and commented them in pyproject.toml
- Updated and validated the sphinx doc build with updated dependencies
- Fixed from attrdict import AttrDict which prohibits Python>=3.10 as it cannot be imported
- Added weldx-widgets>=0.3.3 as a dependency. After changes [#183](https://github.com/BAMWelDX/weldx-widgets/pull/183) the dependency conflics with matplotlib and python>=3.10 were solved. (Tested locally for 3.9 - 3.13)

Detailed description in CHANGELOG.md

All changes including builds were tested locally but must be tested using the CI/CD pipeline.
## Related Issues

## Checks

- [x] updated `CHANGELOG.md`
- [ ] updated `tests/`
- [ ] updated `doc/`
- [ ] update example/tutorial notebooks
- [ ] update manifest file
