### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Release Notes
 
-## 0.7.4 (unreleased)
+## 0.8.0 (21.08.2026)
+
+Release `0.8.0` is a maintenance and compatibility release improve the developer workflows and support never dependency versions.
+
+Newly supported version include:
+
+- `python=3.14`
+- `asdf=5`
+- `numpy>=1.17`
+- `pint-xarray>=0.5`
+
+The minimum required Python version is now `python>=3.10`.
+The next release will increase the minimum required versions for all core dependencies.
 
 ### Fixes
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@
 cff-version: 1.2.0
 title: "weldx: The welding data exchange format"
 type: software
-version: v0.7.3
-date-released: 2026-03-02
+version: v0.8.0
+date-released: 2026-08-21
 license: BSD-3-Clause
 authors:
   - affiliation: "Bundesanstalt für Materialforschung und -prüfung (BAM)"

--- a/README.md
+++ b/README.md
@@ -2,18 +2,15 @@
 
 <hl/>
 
-[![CF](https://anaconda.org/conda-forge/weldx/badges/version.svg)](https://anaconda.org/conda-forge/weldx)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/5e7ede6d978249a781e5c580ed1c813f)](https://www.codacy.com/gh/BAMWelDX/weldx)
-[![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/BAMWelDX/weldx/?ref=repository-badge)
-[![Documentation](https://readthedocs.org/projects/weldx/badge/?version=latest)](https://weldx.readthedocs.io/en/latest/?badge=latest)
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-orange.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.5565185.svg)](https://doi.org/10.5281/zenodo.5565185)
-[![codecov](https://codecov.io/gh/BAMWelDX/weldx/branch/master/graph/badge.svg)](https://codecov.io/gh/BAMWelDX/weldx)
-[![package builds](https://github.com/BAMWelDX/weldx/actions/workflows/build_pkg.yml/badge.svg)](https://github.com/BAMWelDX/weldx/actions/workflows/build_pkg.yml)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-orange.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![CF](https://anaconda.org/conda-forge/weldx/badges/version.svg)](https://anaconda.org/conda-forge/weldx)
+[![Documentation](https://readthedocs.org/projects/weldx/badge/?version=latest)](https://weldx.readthedocs.io/en/latest/?badge=latest)
+[![builds](https://github.com/BAMWelDX/weldx/actions/workflows/build.yml/badge.svg)](https://github.com/BAMWelDX/weldx/actions/workflows/build.yml)
 [![documentation builds](https://github.com/BAMWelDX/weldx/actions/workflows/docs.yml/badge.svg)](https://github.com/BAMWelDX/weldx/actions/workflows/docs.yml)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/BAMWelDX/weldx/master.svg)](https://results.pre-commit.ci/latest/github/BAMWelDX/weldx/master)
 [![pytest](https://github.com/BAMWelDX/weldx/actions/workflows/pytest.yml/badge.svg)](https://github.com/BAMWelDX/weldx/actions/workflows/pytest.yml)
-[![static analysis](https://github.com/BAMWelDX/weldx/actions/workflows/static_analysis.yml/badge.svg)](https://github.com/BAMWelDX/weldx/actions/workflows/static_analysis.yml)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/BAMWelDX/weldx/master.svg)](https://results.pre-commit.ci/latest/github/BAMWelDX/weldx/master)
+[![codecov](https://codecov.io/gh/BAMWelDX/weldx/branch/master/graph/badge.svg)](https://codecov.io/gh/BAMWelDX/weldx)
 
 ## Overview
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,8 +22,7 @@ A short primer in the steps needed to release a new version of the `weldx` packa
 
 - [ ] tag and release the current master version on GitHub using the **Releases** feature
   - [ ] name the release **git tag** according to the version released (e.g. **v0.3.3**)
-  - [ ] name the GitHub release accordingly, omitting the **v** prefix (this can be change later so don't worry, in
-    doubt use **vX.Y.Z** everywhere)
+  - [ ] name the GitHub release accordingly
   - [ ] copy the changes/release notes of the current version into the description and change the GitHub PR links to GitHub markdown
 - [ ] wait for all Github Actions to finish
 


### PR DESCRIPTION
# How to release

A short primer in the steps needed to release a new version of the `weldx` package

## create release PR

- [x] create a PR that finalizes the code for the next version
  - [x] name the PR according to the version `vX.Y.Z` and add the `release`
    tag ([example here](https://github.com/BAMWelDX/weldx/pull/419))
  - [x] make sure `CHANGELOG.md` is up-to-date and enter current date to the release version
  - [x] add summarized release highlights where appropriate
  - [x] update the `CITATION.cff` version number and date
  - [x] search the project for `deprecated` and remove deprecated code
- [x] wait for review and the CI jobs to finish
- [ ] check the readthedocs PR build

## Merge the Pull Request

- [ ] merge normally and wait for all CI actions to finish on the main branch

## add Git(hub) tag

- [ ] tag and release the current master version on GitHub using the **Releases** feature
  - [ ] name the release **git tag** according to the version released (e.g. **v0.3.3**)
  - [ ] name the GitHub release accordingly
  - [ ] copy the changes/release notes of the current version into the description and change the GitHub PR links to GitHub markdown
- [ ] wait for all Github Actions to finish

## ReadTheDocs updates

- [ ] check the build processes for `latest`, `stable` and `vX.Y.Z` get triggered on RTD (the tag build can get
  triggered twice, resulting in a failed/duplicated build, no need to worry)

## pypi release

- [ ] check the automatic release to pypi after the `build` action completes [here](https://pypi.org/project/weldx/)

## conda-forge release

- pypi release should get picked up by the conda-forge bot and create the new
  pull-request [here](https://github.com/conda-forge/weldx-feedstock/pulls)
- [ ] carefully check the `recipe.yaml` in the pull request, manually update all changes in the build and run dependencies
- [ ] merge with 2 or more approved reviews
